### PR TITLE
Fix failure on Python 2.x

### DIFF
--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -4,7 +4,7 @@ try:
     import builtins
 except ImportError:
     # for python 2.x
-    builtins = __builtins__
+    import __builtin__ as builtins
 
 from pythonosc import osc_message
 from pythonosc.parsing import osc_types


### PR DESCRIPTION
Would fail with `AttributeError: 'dict' object has no attribute 'str'` because `__builtins__` is a dict in modules. There is a `__builtin__` module in the standard library that does what is wanted here.
