### PR TITLE
Changed Dispatcher.map to a default dict to support multiple mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+python_osc.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,57 @@
-__pycache__
-python_osc.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -25,6 +25,9 @@ class Dispatcher(object):
       - args: Any additional arguments that will be always passed to the
               handlers after the osc messages arguments if any.
     """
+    # TODO: Check the spec:
+    # http://opensoundcontrol.org/spec-1_0
+    # regarding multiple mappings
     self._map[address].append(Handler(handler, list(args)))
 
   def handlers_for_address(self, address_pattern):
@@ -45,8 +48,8 @@ class Dispatcher(object):
     matched = False
 
     for addr, handlers in self._map.items():
-      if pattern.match(addr) \
-        or (('*' in addr) and re.match(addr.replace('*','[^/]*?/*'), address_pattern)):
+      if (pattern.match(addr)
+        or (('*' in addr) and re.match(addr.replace('*','[^/]*?/*'), address_pattern))):
         yield from handlers
         matched = True
 

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -31,7 +31,7 @@ class Dispatcher(object):
     self._map[address].append(Handler(handler, list(args)))
 
   def handlers_for_address(self, address_pattern):
-    """Return a tuple of Handler namedtuple matching the given OSC pattern."""
+    """yields Handler namedtuples matching the given OSC pattern."""
     # First convert the address_pattern into a matchable regexp.
     # '?' in the OSC Address Pattern matches any single character.
     # Let's consider numbers and _ "characters" too here, it's not said

--- a/pythonosc/test/test_dispatcher.py
+++ b/pythonosc/test/test_dispatcher.py
@@ -13,20 +13,21 @@ class TestDispatcher(unittest.TestCase):
     return self.assertSequenceEqual(sorted(expected), sorted(result))
 
   def test_empty_by_default(self):
-    self.assertEqual([], self.dispatcher.handlers_for_address('/test'))
+    self.sortAndAssertSequenceEqual([], self.dispatcher.handlers_for_address('/test'))
 
   def test_use_default_handler_when_set_and_no_match(self):
     handler = object()
     self.dispatcher.set_default_handler(handler)
-    self.assertEqual([dispatcher.Handler(handler, [])], self.dispatcher.handlers_for_address('/test'))
+
+    self.sortAndAssertSequenceEqual([dispatcher.Handler(handler, [])], self.dispatcher.handlers_for_address('/test'))
 
   def test_simple_map_and_match(self):
     handler = object()
     self.dispatcher.map('/test', handler, 1, 2, 3)
     self.dispatcher.map('/test2', handler)
-    self.assertEqual(
-        [(handler, [1, 2, 3])], self.dispatcher.handlers_for_address('/test'))
-    self.assertEqual(
+    self.sortAndAssertSequenceEqual(
+        [dispatcher.Handler(handler, [1, 2, 3])], self.dispatcher.handlers_for_address('/test'))
+    self.sortAndAssertSequenceEqual(
         [dispatcher.Handler(handler, [])], self.dispatcher.handlers_for_address('/test2'))
 
   def test_example_from_spec(self):
@@ -42,7 +43,7 @@ class TestDispatcher(unittest.TestCase):
       self.dispatcher.map(address, index)
 
     for index, address in enumerate(addresses):
-      self.assertListEqual(
+      self.sortAndAssertSequenceEqual(
           [(index, [])], self.dispatcher.handlers_for_address(address))
 
     self.sortAndAssertSequenceEqual(
@@ -105,6 +106,18 @@ class TestDispatcher(unittest.TestCase):
         [(1, [])], self.dispatcher.handlers_for_address("/foo/wild/bar/wild"))
     self.sortAndAssertSequenceEqual(
         [], self.dispatcher.handlers_for_address("/foo/wild/nomatch/wild"))
+
+  def test_multiple_handlers(self):
+    self.dispatcher.map('/foo/bar', 1)
+    self.dispatcher.map('/foo/bar', 2)
+    self.sortAndAssertSequenceEqual(
+        [dispatcher.Handler(1, []), dispatcher.Handler(2, [])], self.dispatcher.handlers_for_address("/foo/bar"))
+
+  def test_multiple_handlers_with_wildcard_map(self):
+    self.dispatcher.map('/foo/bar', 1)
+    self.dispatcher.map('/*', 2)
+    self.sortAndAssertSequenceEqual(
+        [dispatcher.Handler(1, []), dispatcher.Handler(2, [])], self.dispatcher.handlers_for_address("/foo/bar"))
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
I wanted to be able to map addresses to more than one handler, and found this TODO in the dispatcher:

>  Check if we need to use a multimap instead, spec is a bit fuzzy about it...

It's not clear to me either whether a dispatcher is required by the spec to allow multiple mappings of the same address. But it made sense in my use case, so this pull request enables it.  So now handler1 and handler2 are both called by this dispatcher:

```Python
dispatcher.map("/foo/bar", handler1)
dispatcher.map("/foo/bar", handler2)
```
I used a defaultdict(list) instead of a multimap, since its in the standard library.

I changed handlers_for_address to return a generator rather than a list of handlers since the list comprehension was getting a little long to read quickly. This meant a few more of the dispatcher tests needed to use the sortAndAssertSequenceEqual (or something, to convert from a generator to a list for assertion), but the tests all pass fine.
