### PR TITLE
added AsyncIOOSCUDPServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ and is currently in a stable state.
 Features
 ========
 
-* UDP blocking/threading/forking server implementations
+* UDP blocking/threading/forking/asyncio server implementations
 * UDP client
 * int, float, string, blob OSC arguments
 * simple OSC address<->callback matching system

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -18,8 +18,18 @@ server.shutdown()
 
 Those servers are using the standard socketserver from the standard library:
 http://docs.python.org/library/socketserver.html
+
+
+Alternatively, the AsyncIOOSCUDPServer server can be integrated with an asyncio event loop:
+
+loop = asyncio.get_event_loop()
+server = AsyncIOOSCUDPServer(server_address, dispatcher, loop)
+server.serve()
+loop.run_forever()
+
 """
 
+import asyncio
 import calendar
 import socketserver
 import time
@@ -28,6 +38,42 @@ from pythonosc import osc_bundle
 from pythonosc import osc_message
 from pythonosc import osc_packet
 
+
+def _handle(data, dispatcher):
+  """
+  This function calls the handlers registered to the dispatcher for
+  every message it found in the packet.
+  The process/thread granularity is thus the OSC packet, not the handler.
+
+  If parameters were registered with the dispatcher, then the handlers are
+  called this way:
+    handler('/address that triggered the message',
+            registered_param_list, osc_msg_arg1, osc_msg_arg2, ...)
+  if no parameters were registered, then it is just called like this:
+    handler('/address that triggered the message',
+            osc_msg_arg1, osc_msg_arg2, osc_msg_param3, ...)
+  """
+
+  # Get OSC messages from all bundles or standalone message.
+  try:
+    packet = osc_packet.OscPacket(data)
+    for timed_msg in packet.messages:
+      now = calendar.timegm(time.gmtime())
+      handlers = dispatcher.handlers_for_address(
+          timed_msg.message.address)
+      if not handlers:
+        continue
+      # If the message is to be handled later, then so be it.
+      if timed_msg.time > now:
+        time.sleep(timed_msg.time - now)
+      for handler in handlers:
+        if handler.args:
+          handler.callback(
+              timed_msg.message.address, handler.args, *timed_msg.message)
+        else:
+          handler.callback(timed_msg.message.address, *timed_msg.message)
+  except osc_packet.ParseError:
+    pass
 
 
 class _UDPHandler(socketserver.BaseRequestHandler):
@@ -40,41 +86,9 @@ class _UDPHandler(socketserver.BaseRequestHandler):
   basically whether this datagram looks like an osc message or bundle,
   if not the server won't even bother to call it and so no new
   threads/processes will be spawned.
-
-  This method calls the handlers registered to the server's dispatcher for
-  every message it found in the packet.
-  The process/thread granularity is thus the OSC packet, not the handler.
-
-  If parameters were registered with the dispatcher, then the handlers are
-  called this way:
-    handler('/address that triggered the message',
-            registered_param_list, osc_msg_arg1, osc_msg_arg2, ...)
-  if no parameters were registered, then it is just called like this:
-    handler('/address that triggered the message',
-            osc_msg_arg1, osc_msg_arg2, osc_msg_param3, ...)
   """
   def handle(self):
-    data = self.request[0]
-    # Get OSC messages from all bundles or standalone message.
-    try:
-      packet = osc_packet.OscPacket(data)
-      for timed_msg in packet.messages:
-        now = calendar.timegm(time.gmtime())
-        handlers = self.server.dispatcher.handlers_for_address(
-            timed_msg.message.address)
-        if not handlers:
-          continue
-        # If the message is to be handled later, then so be it.
-        if timed_msg.time > now:
-          time.sleep(timed_msg.time - now)
-        for handler in handlers:
-          if handler.args:
-            handler.callback(
-                timed_msg.message.address, handler.args, *timed_msg.message)
-          else:
-            handler.callback(timed_msg.message.address, *timed_msg.message)
-    except osc_packet.ParseError:
-      pass
+    _handle(self.request[0], self.server.dispatcher)
 
 
 def _is_valid_request(request):
@@ -85,7 +99,24 @@ def _is_valid_request(request):
       or osc_message.OscMessage.dgram_is_message(data))
 
 
-class BlockingOSCUDPServer(socketserver.UDPServer):
+class OSCUDPServer(socketserver.UDPServer):
+  """Superclass for different flavors of OSCUDPServer"""
+
+  def __init__(self, server_address, dispatcher):
+    super().__init__(server_address, _UDPHandler)
+    self._dispatcher = dispatcher
+
+  def verify_request(self, request, client_address):
+    """Returns true if the data looks like a valid OSC UDP datagram."""
+    return _is_valid_request(request)
+
+  @property
+  def dispatcher(self):
+    """Dispatcher accessor for handlers to dispatch osc messages."""
+    return self._dispatcher
+
+
+class BlockingOSCUDPServer(OSCUDPServer):
   """Blocking version of the UDP server.
 
   Each message will be handled sequentially on the same thread.
@@ -93,44 +124,18 @@ class BlockingOSCUDPServer(socketserver.UDPServer):
   have a multiprocess/multithread environment (really?).
   """
 
-  def __init__(self, server_address, dispatcher):
-    super().__init__(server_address, _UDPHandler)
-    self._dispatcher = dispatcher
-
-  def verify_request(self, request, client_address):
-    """Returns true if the data looks like a valid OSC UDP datagram."""
-    return _is_valid_request(request)
-
-  @property
-  def dispatcher(self):
-    """Dispatcher accessor for handlers to dispatch osc messages."""
-    return self._dispatcher
-
 
 class ThreadingOSCUDPServer(
-    socketserver.ThreadingMixIn, socketserver.UDPServer):
+    socketserver.ThreadingMixIn, OSCUDPServer):
   """Threading version of the OSC UDP server.
 
   Each message will be handled in its own new thread.
   Use this when lightweight operations are done by each message handlers.
   """
 
-  def __init__(self, server_address, dispatcher):
-    super().__init__(server_address, _UDPHandler)
-    self._dispatcher = dispatcher
-
-  def verify_request(self, request, client_address):
-    """Returns true if the data looks like a valid OSC UDP datagram."""
-    return _is_valid_request(request)
-
-  @property
-  def dispatcher(self):
-    """Dispatcher accessor for handlers to dispatch osc messages."""
-    return self._dispatcher
-
 
 class ForkingOSCUDPServer(
-    socketserver.ForkingMixIn, socketserver.UDPServer):
+    socketserver.ForkingMixIn, OSCUDPServer):
   """Forking version of the OSC UDP server.
 
   Each message will be handled in its own new process.
@@ -138,15 +143,36 @@ class ForkingOSCUDPServer(
   and forking a whole new process for each of them is worth it.
   """
 
-  def __init__(self, server_address, dispatcher):
-    super().__init__(server_address, _UDPHandler)
-    self._dispatcher = dispatcher
 
-  def verify_request(self, request, client_address):
-    """Returns true if the data looks like a valid OSC UDP datagram."""
-    return _is_valid_request(request)
+class AsyncIOOSCUDPServer():
+  """Asyncio version of the OSC UDP Server.
+
+  :param server_address: tuple of (IP address to bind to, port)
+  :param dispatcher: a pythonosc.dispatcher.Dispatcher
+  :param loop: an asyncio event loop
+
+  Each UDP message is handled by _handle, the same method as in the OSCUDPServer family of blocking, threading, and forking servers
+  """
+
+  def __init__(self, server_address, dispatcher, loop):
+    self._server_address = server_address
+    self._dispatcher = dispatcher
+    self._loop = loop
+
+  class OSCProtocolFactory(asyncio.DatagramProtocol):
+    """OSC protocol factory which passes datagrams to _handle"""
+
+    def __init__(self, dispatcher):
+      self.dispatcher = dispatcher
+
+    def datagram_received(self, data, addr):
+      _handle(data, self.dispatcher)
+
+  def serve(self):
+    """creates a datagram endpoint and registers it with our event loop"""
+    listen = self._loop.create_datagram_endpoint(lambda: self.OSCProtocolFactory(self.dispatcher), local_addr=self._server_address)
+    transport, protocol = self._loop.run_until_complete(listen)
 
   @property
   def dispatcher(self):
-    """Dispatcher accessor for handlers to dispatch osc messages."""
     return self._dispatcher


### PR DESCRIPTION
This change adds an AsyncIOOSCUDPServer.  Its intended use is as an alternative to the existing threading/forking servers which uses the asyncio module.

The logic of _UDPHandler.handle was moved into a _handle function so the different datagram mechanisms of the socketserver servers and the asyncio server could use the same handling code.

The existing *OSCUDPServer classes all shared the same methods, so they were pushed into a superclass, OSCUDPServer.  There were no logical changes to them other than that refactor.

The new class can be used like this:

loop = asyncio.get_event_loop()
server = AsyncIOOSCUDPServer(server_address, dispatcher, loop)
server.serve()
loop.run_forever()
