### PR TITLE
Python2.x compatibility

### DIFF
--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -59,9 +59,10 @@ def get_string(dgram, start_index):
   Raises:
     ParseError if the datagram could not be parsed.
   """
+  nul = b'\0'[0]
   offset = 0
   try:
-    while dgram[start_index + offset] != 0:
+    while dgram[start_index + offset] != nul:
       offset += 1
     if offset == 0:
       raise ParseError(


### PR DESCRIPTION
In Python 2.x `bytes` are just strings, so indexing them returns a single-character string, not a number, therefore the `while` loop never terminates and `get_string` fails with the following error:
```
  File ".../pythonosc/osc_message_builder.py", line 120, in build
    return osc_message.OscMessage(dgram)
  File ".../pythonosc/osc_message.py", line 22, in __init__
    self._parse_datagram()
  File ".../pythonosc/osc_message.py", line 56, in _parse_datagram
    raise ParseError('Found incorrect datagram, ignoring it', pe)
pythonosc.osc_message.ParseError: ('Found incorrect datagram, ignoring it', ParseError('Could not parse datagram string index out of range',))
```
This fixes it by looking for the correct type in all Python versions.