### PR TITLE
Fix malformed packet when no arguments provided

### DIFF
--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -97,6 +97,7 @@ class OscMessageBuilder(object):
       # Write the address.
       dgram += osc_types.write_string(self._address)
       if not self._args:
+        dgram += osc_types.write_string(',')
         return osc_message.OscMessage(dgram)
 
       # Write the parameters.

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -46,6 +46,13 @@ class TestOscMessageBuilder(unittest.TestCase):
     builder.add_arg('this is not a float', builder.ARG_TYPE_FLOAT)
     self.assertRaises(osc_message_builder.BuildError, builder.build)
 
+  def test_build_noarg_message(self):
+    msg = osc_message_builder.OscMessageBuilder(address='/SYNC').build()
+    # This reference message was generated with Cycling 74's Max software
+    # and then was intercepted with Wireshark
+    reference = bytearray.fromhex('2f53594e430000002c000000')
+    self.assertSequenceEqual(msg._dgram, reference)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
No-args message didn't contain the empty typetag, and other software, like Max, couldn't parse empty message.