### PR TITLE
ntp timestamp conversion seems to be off ... 

### DIFF
--- a/pythonosc/parsing/ntp.py
+++ b/pythonosc/parsing/ntp.py
@@ -5,6 +5,9 @@ import struct
 import time
 
 
+JAN_1970 = 2208988800
+SECS_TO_PICOS = 4294967296
+
 # 63 zero bits followed by a one in the least signifigant bit is a special
 # case meaning "immediately."
 IMMEDIATELY = struct.pack('>q', 1)
@@ -26,15 +29,12 @@ def ntp_to_system_time(date):
     """
     return date - _NTP_DELTA
 
-
 def system_time_to_ntp(date):
-    """Convert a system time to a NTP time datagram.
-
-    System time is reprensented by seconds since the epoch in UTC.
-    """
-    try:
-      ntp = date + _NTP_DELTA
-    except TypeError as ve:
-      raise NtpError('Invalud date: {}'.format(ve))
-    num_secs, fraction = str(ntp).split('.')
-    return struct.pack('>I', int(num_secs)) + struct.pack('>I', int(fraction))
+    """ since 1970 => since 1900 64b OSC """
+    sec_1970 = int(date)
+    sec_1900 = sec_1970 + JAN_1970
+    
+    sec_frac = float(date - sec_1970)
+    picos = int(sec_frac * SECS_TO_PICOS)
+    
+    return struct.pack('>I', int(sec_1900)) + struct.pack('>I', picos)

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -112,7 +112,7 @@ def get_int(dgram, start_index):
     if len(dgram[start_index:]) < _INT_DGRAM_LEN:
       raise ParseError('Datagram is too short')
     return (
-        struct.unpack('>i',
+        struct.unpack('>I',
                       dgram[start_index:start_index + _INT_DGRAM_LEN])[0],
         start_index + _INT_DGRAM_LEN)
   except (struct.error, TypeError) as e:

--- a/pythonosc/test/parsing/test_osc_types.py
+++ b/pythonosc/test/parsing/test_osc_types.py
@@ -164,7 +164,7 @@ class TestNTPTimestamp(unittest.TestCase):
     self.assertRaises(osc_types.ParseError, osc_types.get_date, dgram, 2)
 
   def test_write_date(self):
-    self.assertEqual(b'\x83\xaa~\x83\x00\x00\x059', osc_types.write_date(3.1337))
+    self.assertEqual(b'\x83\xaa~\x83\":)\xc7', osc_types.write_date(3.1337))
 
 
 class TestBuildMethods(unittest.TestCase):


### PR DESCRIPTION
With the original implementation, i permanently got "late ..." messages when sending OSC bundles to ScSynth (locally) , even with half a second latency added.

So i ported the implementation from the OSC module, as found here:

http://trac.assembla.com/pkaudio/browser/scosc/tools.py#L105

With the changed implementation, there are no more "late ..." messages in SySynth, even with latencys as small as 10ms.