### PR TITLE
Ntp fix

### DIFF
--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -31,7 +31,6 @@ loop.run_forever()
 """
 
 import asyncio
-import calendar
 import socketserver
 import time
 
@@ -59,7 +58,7 @@ def _call_handlers_for_packet(data, dispatcher):
   try:
     packet = osc_packet.OscPacket(data)
     for timed_msg in packet.messages:
-      now = calendar.timegm(time.gmtime())
+      now = time.time()
       handlers = dispatcher.handlers_for_address(
           timed_msg.message.address)
       if not handlers:

--- a/pythonosc/parsing/ntp.py
+++ b/pythonosc/parsing/ntp.py
@@ -4,8 +4,8 @@ import datetime
 import struct
 import time
 
-# conversion factor for fractional seconds ... some bitwise magic, i suppose ?
-_FRACTIONAL_CONVERSION = 4294967296
+# conversion factor for fractional seconds (maximum value of fractional part)
+FRACTIONAL_CONVERSION = 2 ** 32
 
 # 63 zero bits followed by a one in the least signifigant bit is a special
 # case meaning "immediately."
@@ -43,6 +43,6 @@ def system_time_to_ntp(date):
     
     sec_frac = float(date - num_secs)
 
-    picos = int(sec_frac * _FRACTIONAL_CONVERSION)
+    picos = int(sec_frac * FRACTIONAL_CONVERSION)
   
     return struct.pack('>I', int(num_secs_ntp)) + struct.pack('>I', picos)

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -226,10 +226,8 @@ def get_date(dgram, start_index):
     raise ParseError('Datagram is too short')
   num_secs, start_index = get_int(dgram, start_index)
   fraction, start_index = get_int(dgram, start_index)
-  # Get a decimal representation from those two values.
-  dec = decimal.Decimal(str(num_secs) + '.' + str(fraction))
-  # And convert it to float simply.
-  system_time = float(dec)
+  # Sum seconds and fraction of second:
+  system_time = num_secs + (fraction / ntp.FRACTIONAL_CONVERSION)
   return ntp.ntp_to_system_time(system_time), start_index
 
 


### PR DESCRIPTION
Thanks for a handy module! I have encountered some timing errors with the ntp conversion, and these changes seem to fix it for me. This blog post was helpful: 
http://thompsonng.blogspot.no/2010/04/ntp-timestamp_21.html
I see that it has already been fixed for the system-time-to-ntp conversion, and I have tried to change it in the same way for ntp-to-system-time conversion for incoming bundles. Also it is very useful (for me, at least) with better precision for the timed messages, so I tried a fix for this as well.