### PR TITLE
[WIP] Support additional type tags

### DIFF
--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -49,11 +49,16 @@ class OscMessage(object):
           val = True
         elif param == "F": # False.
           val = False
+        elif param == "N": # Nil (None)
+          val = None
+        elif param == 'I': # Infinitum (no data)
+          val = None
         # TODO: Support more exotic types as described in the specification.
         else:
           logging.warning('Unhandled parameter type: {0}'.format(param))
           continue
-        self._parameters.append(val)
+        if param != 'I':
+          self._parameters.append(val)
     except osc_types.ParseError as pe:
       raise ParseError('Found incorrect datagram, ignoring it', pe)
 

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -115,8 +115,8 @@ class OscMessageBuilder(object):
           dgram += osc_types.write_blob(value)
         elif arg_type == self.ARG_TYPE_RGBA:
           dgram += osc_types.write_rgba(value)
-        elif arg_type in [self.ARG_TYPE_TRUE, self.ARG_TYPE_FALSE,
-                          self.ARG_TYPE_NIL, self.ARG_TYPE_INFINITUM]:
+        elif arg_type in (self.ARG_TYPE_TRUE, self.ARG_TYPE_FALSE,
+                          self.ARG_TYPE_NIL, self.ARG_TYPE_INFINITUM):
           continue
         else:
           raise BuildError('Incorrect parameter type found {}'.format(

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -18,9 +18,12 @@ class OscMessageBuilder(object):
   ARG_TYPE_RGBA = "r"
   ARG_TYPE_TRUE = "T"
   ARG_TYPE_FALSE = "F"
+  ARG_TYPE_NIL = "N"
+  ARG_TYPE_INFINITUM = "I"
 
   _SUPPORTED_ARG_TYPES = (
-      ARG_TYPE_FLOAT, ARG_TYPE_INT, ARG_TYPE_BLOB, ARG_TYPE_STRING, ARG_TYPE_RGBA, ARG_TYPE_TRUE, ARG_TYPE_FALSE)
+      ARG_TYPE_FLOAT, ARG_TYPE_INT, ARG_TYPE_BLOB, ARG_TYPE_STRING, ARG_TYPE_RGBA, ARG_TYPE_TRUE, ARG_TYPE_FALSE,
+      ARG_TYPE_NIL, ARG_TYPE_INFINITUM)
 
   def __init__(self, address=None):
     """Initialize a new builder for a message.
@@ -72,6 +75,8 @@ class OscMessageBuilder(object):
         arg_type = self.ARG_TYPE_TRUE
       elif arg_value == False:
         arg_type = self.ARG_TYPE_FALSE
+      elif arg_value is None:
+        arg_type = self.ARG_TYPE_NIL
       else:
         raise ValueError('Infered arg_value type is not supported')
     self._args.append((arg_type, arg_value))
@@ -110,7 +115,8 @@ class OscMessageBuilder(object):
           dgram += osc_types.write_blob(value)
         elif arg_type == self.ARG_TYPE_RGBA:
           dgram += osc_types.write_rgba(value)
-        elif arg_type == self.ARG_TYPE_TRUE or arg_type == self.ARG_TYPE_FALSE:
+        elif arg_type in [self.ARG_TYPE_TRUE, self.ARG_TYPE_FALSE,
+                          self.ARG_TYPE_NIL, self.ARG_TYPE_INFINITUM]:
           continue
         else:
           raise BuildError('Incorrect parameter type found {}'.format(

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -31,6 +31,7 @@ class TestOscMessageBuilder(unittest.TestCase):
     builder.add_arg("value")
     builder.add_arg(True)
     builder.add_arg(False)
+    builder.add_arg(None)
     builder.add_arg(b"\x01\x02\x03")
     # The same args but with explicit types.
     builder.add_arg(4.0, builder.ARG_TYPE_FLOAT)
@@ -38,15 +39,16 @@ class TestOscMessageBuilder(unittest.TestCase):
     builder.add_arg("value", builder.ARG_TYPE_STRING)
     builder.add_arg(True)
     builder.add_arg(False)
+    builder.add_arg(None)
     builder.add_arg(b"\x01\x02\x03", builder.ARG_TYPE_BLOB)
     builder.add_arg(4278255360, builder.ARG_TYPE_RGBA)
-    self.assertEqual(13, len(builder.args))
+    self.assertEqual(15, len(builder.args))
     self.assertEqual("/SYNC", builder.address)
     builder.address = '/SEEK'
     msg = builder.build()
     self.assertEqual("/SEEK", msg.address)
     self.assertSequenceEqual(
-        [4.0, 2, "value", True, False, b"\x01\x02\x03"] * 2 + [4278255360], msg.params)
+        [4.0, 2, "value", True, False, None, b"\x01\x02\x03"] * 2 + [4278255360], msg.params)
 
   def test_empty_param_types(self):
     builder = osc_message_builder.OscMessageBuilder(address="/SYNC")

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -48,6 +48,12 @@ class TestOscMessageBuilder(unittest.TestCase):
     self.assertSequenceEqual(
         [4.0, 2, "value", True, False, b"\x01\x02\x03"] * 2 + [4278255360], msg.params)
 
+  def test_empty_param_types(self):
+    builder = osc_message_builder.OscMessageBuilder(address="/SYNC")
+    builder.add_arg(None)
+    msg = builder.build()
+    self.assertEqual([None], msg.params)
+
   def test_build_wrong_type_raises(self):
     builder = osc_message_builder.OscMessageBuilder(address="/SYNC")
     builder.add_arg('this is not a float', builder.ARG_TYPE_FLOAT)

--- a/pythonosc/test/test_osc_packet.py
+++ b/pythonosc/test/test_osc_packet.py
@@ -53,6 +53,7 @@ _DGRAM_NESTED_MESS = (
     b",f\x00\x00"
     b"?\x00\x00\x00")
 
+_DGRAM_INFINITUM_MESSAGE = b'/SYNC\x00\x00\x00,I\x00\x00'
 
 class TestOscPacket(unittest.TestCase):
 
@@ -74,6 +75,10 @@ class TestOscPacket(unittest.TestCase):
     self.assertTrue(packet.messages[1][0], packet.messages[2][0])
     self.assertTrue(packet.messages[2][0], packet.messages[3][0])
 
+  def test_infinitum_message(self):
+    packet = osc_packet.OscPacket(_DGRAM_INFINITUM_MESSAGE)
+    self.assertEqual(1, len(packet.messages))
+    self.assertEqual(0, len(packet.messages[0][1].params))
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
* Add `N` (Nil or `None`) type tag
* Add `I` (Infinitum) type tag.  This wouldn't be necessary for `OscMessage` building, but it would be good to allow it to parse without raising exceptions

Additional types (todo):
- [ ] `m` 4-byte MIDI message
- [ ] `t` OSC-timetag
- [ ] Any suggestions?