### PR TITLE
Correctly set the message type for booleans

### DIFF
--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -95,14 +95,14 @@ class OscMessageBuilder(object):
       arg_type = self.ARG_TYPE_STRING
     elif isinstance(arg_value, bytes):
       arg_type = self.ARG_TYPE_BLOB
-    elif isinstance(arg_value, int):
-      arg_type = self.ARG_TYPE_INT
-    elif isinstance(arg_value, float):
-      arg_type = self.ARG_TYPE_FLOAT
     elif arg_value == True:
       arg_type = self.ARG_TYPE_TRUE
     elif arg_value == False:
       arg_type = self.ARG_TYPE_FALSE
+    elif isinstance(arg_value, int):
+      arg_type = self.ARG_TYPE_INT
+    elif isinstance(arg_value, float):
+      arg_type = self.ARG_TYPE_FLOAT
     elif isinstance(arg_value, list):
       arg_type = [self._get_arg_type(v) for v in arg_value]
     else:


### PR DESCRIPTION
```
>>> isinstance(True, int)
True
```
 
See https://stackoverflow.com/questions/37888620/python-comparing-boolean-and-int-using-isinstance