### PR TITLE
Fix zero-termination of strings

### DIFF
--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -61,7 +61,7 @@ def get_string(dgram, start_index):
   """
   offset = 0
   try:
-    while dgram[start_index + offset] != 0:
+    while dgram[start_index + offset] != '\x00':
       offset += 1
     if offset == 0:
       raise ParseError(


### PR DESCRIPTION
For me the 0 in the comparison on line 64 was not working, when replacing 0 with '\x00' it started working.