### PR TITLE
can now parse osc time tags

### DIFF
--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -47,6 +47,8 @@ class OscMessage(object):
           val, index = osc_types.get_blob(self._dgram, index)
         elif param == "r":  # RGBA.
           val, index = osc_types.get_rgba(self._dgram, index)
+        elif param == "t": # osc time tag:
+            val, index = osc_types.get_ttag(self._dgram, index)
         elif param == "T": # True.
           val = True
         elif param == "F": # False.

--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -47,13 +47,13 @@ class OscMessage(object):
           val, index = osc_types.get_blob(self._dgram, index)
         elif param == "r":  # RGBA.
           val, index = osc_types.get_rgba(self._dgram, index)
-        elif param == "t": # osc time tag:
+        elif param == "t":  # osc time tag:
             val, index = osc_types.get_ttag(self._dgram, index)
-        elif param == "T": # True.
+        elif param == "T":  # True.
           val = True
-        elif param == "F": # False.
+        elif param == "F":  # False.
           val = False
-        elif param == "[": # Array start.
+        elif param == "[":  # Array start.
           array = []
           param_stack[-1].append(array)
           param_stack.append(array)

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -145,17 +145,15 @@ def get_ttag(dgram, start_index):
     second_decimals, _ = get_int(dgram, idx)
 
     if seconds < 0:
-      seconds += 1 << 32
+      seconds += ntp.FRACTIONAL_CONVERSION
 
     if second_decimals < 0:
-      second_decimals += 1 << 32
+      second_decimals += ntp.FRACTIONAL_CONVERSION
 
     hours, seconds = seconds // 3600, seconds % 3600
     minutes, seconds = seconds // 60, seconds % 60
 
     utc = datetime.combine(ntp._NTP_EPOCH, datetime.min.time()) + timedelta(hours=hours, minutes=minutes, seconds=seconds)
-
-    print(utc, second_decimals)
 
     return (utc, second_decimals), start_index + _TTAG_DGRAM_LEN
   except (struct.error, TypeError) as e:

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -4,6 +4,7 @@ import decimal
 import struct
 
 from pythonosc.parsing import ntp
+from datetime import datetime, timedelta
 
 
 class ParseError(Exception):
@@ -115,6 +116,41 @@ def get_int(dgram, start_index):
         struct.unpack('>i',
                       dgram[start_index:start_index + _INT_DGRAM_LEN])[0],
         start_index + _INT_DGRAM_LEN)
+  except (struct.error, TypeError) as e:
+    raise ParseError('Could not parse datagram %s' % e)
+
+
+def get_ttag(dgram, start_index):
+  """Get a 64-bit OSC time tag from the datagram.
+
+  Args:
+    dgram: A datagram packet.
+    start_index: An index where the osc time tag starts in the datagram.
+
+  Returns:
+    A tuple containing the time of sending in utc as datetime and the new end index.
+
+  Raises:
+    ParseError if the datagram could not be parsed.
+  """
+
+  _TTAG_DGRAM_LEN = 8
+  _OSC_BEGIN_OF_TIME = datetime(1900, 1, 1, 0, 0, 0)
+
+  try:
+    if len(dgram[start_index:]) < _TTAG_DGRAM_LEN:
+      raise ParseError('Datagram is too short')
+
+    seconds, _ = get_int(dgram, start_index)
+
+    seconds += 1 << 32
+
+    hours, seconds = seconds // 3600, seconds % 3600
+    minutes, seconds = seconds // 60, seconds % 60
+
+    utc = _OSC_BEGIN_OF_TIME + timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+    return utc, start_index + _TTAG_DGRAM_LEN
   except (struct.error, TypeError) as e:
     raise ParseError('Could not parse datagram %s' % e)
 

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -4,7 +4,7 @@ import decimal
 import struct
 
 from pythonosc.parsing import ntp
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 
 class ParseError(Exception):
@@ -128,29 +128,36 @@ def get_ttag(dgram, start_index):
     start_index: An index where the osc time tag starts in the datagram.
 
   Returns:
-    A tuple containing the time of sending in utc as datetime and the new end index.
+    A tuple containing the tuple of time of sending in utc as datetime and the
+    fraction of the current second and the new end index.
 
   Raises:
     ParseError if the datagram could not be parsed.
   """
 
   _TTAG_DGRAM_LEN = 8
-  _OSC_BEGIN_OF_TIME = datetime(1900, 1, 1, 0, 0, 0)
 
   try:
     if len(dgram[start_index:]) < _TTAG_DGRAM_LEN:
       raise ParseError('Datagram is too short')
 
-    seconds, _ = get_int(dgram, start_index)
+    seconds, idx = get_int(dgram, start_index)
+    second_decimals, _ = get_int(dgram, idx)
 
-    seconds += 1 << 32
+    if seconds < 0:
+      seconds += 1 << 32
+
+    if second_decimals < 0:
+      second_decimals += 1 << 32
 
     hours, seconds = seconds // 3600, seconds % 3600
     minutes, seconds = seconds // 60, seconds % 60
 
-    utc = _OSC_BEGIN_OF_TIME + timedelta(hours=hours, minutes=minutes, seconds=seconds)
+    utc = datetime.combine(ntp._NTP_EPOCH, datetime.min.time()) + timedelta(hours=hours, minutes=minutes, seconds=seconds)
 
-    return utc, start_index + _TTAG_DGRAM_LEN
+    print(utc, second_decimals)
+
+    return (utc, second_decimals), start_index + _TTAG_DGRAM_LEN
   except (struct.error, TypeError) as e:
     raise ParseError('Could not parse datagram %s' % e)
 
@@ -264,6 +271,9 @@ def get_date(dgram, start_index):
   fraction, start_index = get_int(dgram, start_index)
   # Sum seconds and fraction of second:
   system_time = num_secs + (fraction / ntp.FRACTIONAL_CONVERSION)
+
+  print(ntp.ntp_to_system_time(system_time))
+
   return ntp.ntp_to_system_time(system_time), start_index
 
 

--- a/pythonosc/test/test_osc_message.py
+++ b/pythonosc/test/test_osc_message.py
@@ -2,6 +2,8 @@ import unittest
 
 from pythonosc import osc_message
 
+from datetime import datetime
+
 
 # Datagrams sent by Reaktor 5.8 by Native Instruments (c).
 _DGRAM_KNOB_ROTATES = (
@@ -31,9 +33,11 @@ _DGRAM_ALL_STANDARD_TYPES_OF_PARAMS = (
 
 _DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS = (
     b"/SYNC\x00\x00\x00"
-    b",T"  # True
+    b"T"  # True
     b"F"  # False
-    b"[]\x00\x00\x00")  # Empty array
+    b"[]\x00\x00\x00" # Empty array
+    b"t\x00\x00\x00\x00\x00\x00\x00\x00"
+    )
 
 _DGRAM_COMPLEX_ARRAY_PARAMS = (
     b"/SYNC\x00\x00\x00"
@@ -95,12 +99,14 @@ class TestOscMessage(unittest.TestCase):
 
   def test_all_non_standard_params(self):
     msg = osc_message.OscMessage(_DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS)
+
     self.assertEqual("/SYNC", msg.address)
-    self.assertEqual(3, len(msg.params))
+    self.assertEqual(4, len(msg.params))
     self.assertEqual(True, msg.params[0])
     self.assertEqual(False, msg.params[1])
     self.assertEqual([], msg.params[2])
-    self.assertEqual(3, len(list(msg)))
+    self.assertEqual((datetime(1900, 1, 1, 0, 0, 0), 0), msg.params[3])
+    self.assertEqual(4, len(list(msg)))
 
   def test_complex_array_params(self):
     msg = osc_message.OscMessage(_DGRAM_COMPLEX_ARRAY_PARAMS)
@@ -108,7 +114,7 @@ class TestOscMessage(unittest.TestCase):
     self.assertEqual(3, len(msg.params))
     self.assertEqual([1], msg.params[0])
     self.assertEqual([["ABC", "DEF"]], msg.params[1])
-    self.assertEqual([[2],[3, ["GHI"]]], msg.params[2])
+    self.assertEqual([[2], [3, ["GHI"]]], msg.params[2])
     self.assertEqual(3, len(list(msg)))
 
   def test_raises_on_empty_datargram(self):


### PR DESCRIPTION
added the case 't' to osc_message.py in order to properly handle ttag parsing in osc_types.py for use in client application (otherwise client applications crash if this type of data shows up).