### PR TITLE
Add unmap method to dispatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 script: python setup.py test

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -4,6 +4,8 @@ import logging
 import re
 import time
 from pythonosc import osc_packet
+from typing import overload
+from types import FunctionType
 
 class Handler(object):
   def __init__(self, _callback, _args, _needs_reply_address=False):
@@ -58,7 +60,18 @@ class Dispatcher(object):
     self._map[address].append(handlerobj)
     return handlerobj
 
-  def unmap(self, address, handler, *args, needs_reply_address=False):
+  @overload
+  def unmap(self, address: str, handler: Handler):
+    """Remove an already mapped handler from an address
+
+        Args:
+          - address: An explicit endpoint.
+          - handler: A Handler object as returned from map().
+    """
+    pass
+
+  @overload
+  def unmap(self, address: str, handler: FunctionType, *args, needs_reply_address: bool=False):
     """Remove an already mapped handler from an address
 
     Args:
@@ -68,8 +81,15 @@ class Dispatcher(object):
       - args: Any additional arguments that will be always passed to the
               handlers after the osc messages arguments if any.
       - needs_reply_address: True if the handler function needs the
-              originating client address passed (as the first argument)."""
-    self._map[address].remove(Handler(handler, list(args), needs_reply_address))
+              originating client address passed (as the first argument).
+    """
+    pass
+
+  def unmap(self, address, handler, *args, needs_reply_address=False):
+    if isinstance(handler, Handler):
+      self._map[address].remove(handler)
+    else:
+      self._map[address].remove(Handler(handler, list(args), needs_reply_address))
 
   def handlers_for_address(self, address_pattern):
     """yields Handler namedtuples matching the given OSC pattern."""

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -54,6 +54,19 @@ class Dispatcher(object):
     # regarding multiple mappings
     self._map[address].append(Handler(handler, list(args), needs_reply_address))
 
+  def unmap(self, address, handler, *args, needs_reply_address=False):
+    """Remove an already mapped handler from an address
+
+    Args:
+      - address: An explicit endpoint.
+      - handler: A function that will be run when the address matches with
+                 the OscMessage passed as parameter.
+      - args: Any additional arguments that will be always passed to the
+              handlers after the osc messages arguments if any.
+      - needs_reply_address: True if the handler function needs the
+              originating client address passed (as the first argument)."""
+    self._map[address].remove(Handler(handler, list(args), needs_reply_address))
+
   def handlers_for_address(self, address_pattern):
     """yields Handler namedtuples matching the given OSC pattern."""
     # First convert the address_pattern into a matchable regexp.

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -48,11 +48,15 @@ class Dispatcher(object):
               handlers after the osc messages arguments if any.
       - needs_reply_address: True if the handler function needs the
               originating client address passed (as the first argument).
+      Returns:
+      - Handler object
     """
     # TODO: Check the spec:
     # http://opensoundcontrol.org/spec-1_0
     # regarding multiple mappings
-    self._map[address].append(Handler(handler, list(args), needs_reply_address))
+    handlerobj = Handler(handler, list(args), needs_reply_address)
+    self._map[address].append(handlerobj)
+    return handlerobj
 
   def unmap(self, address, handler, *args, needs_reply_address=False):
     """Remove an already mapped handler from an address

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -86,10 +86,14 @@ class Dispatcher(object):
     pass
 
   def unmap(self, address, handler, *args, needs_reply_address=False):
-    if isinstance(handler, Handler):
-      self._map[address].remove(handler)
-    else:
-      self._map[address].remove(Handler(handler, list(args), needs_reply_address))
+    try:
+      if isinstance(handler, Handler):
+        self._map[address].remove(handler)
+      else:
+        self._map[address].remove(Handler(handler, list(args), needs_reply_address))
+    except ValueError as e:
+      if str(e) == "list.remove(x): x not in list":
+        raise ValueError("Address '%s' doesn't have handler '%s' mapped to it" % (address, handler)) from e
 
   def handlers_for_address(self, address_pattern):
     """yields Handler namedtuples matching the given OSC pattern."""

--- a/pythonosc/test/test_dispatcher.py
+++ b/pythonosc/test/test_dispatcher.py
@@ -137,5 +137,16 @@ class TestDispatcher(unittest.TestCase):
     self.dispatcher.unmap("/map/me/too", dummyhandler)
     self.sortAndAssertSequenceEqual([], self.dispatcher.handlers_for_address("/map/me/too"))
 
+  def test_unmap_exception(self):
+    def dummyhandler():
+        pass
+
+    with self.assertRaises(ValueError) as context:
+      self.dispatcher.unmap("/unmap/exception", dummyhandler)
+
+    handlerobj = self.dispatcher.map("/unmap/somethingelse", dummyhandler())
+    with self.assertRaises(ValueError) as context:
+      self.dispatcher.unmap("/unmap/exception", handlerobj)
+
 if __name__ == "__main__":
   unittest.main()

--- a/pythonosc/test/test_dispatcher.py
+++ b/pythonosc/test/test_dispatcher.py
@@ -125,10 +125,17 @@ class TestDispatcher(unittest.TestCase):
     def dummyhandler():
         pass
 
-    self.dispatcher.map("/map/me", dummyhandler)
+    # Test with handler returned by map
+    returnedhandler = self.dispatcher.map("/map/me", dummyhandler)
     self.sortAndAssertSequenceEqual([Handler(dummyhandler, [])], self.dispatcher.handlers_for_address("/map/me"))
-    self.dispatcher.unmap("/map/me", dummyhandler)
+    self.dispatcher.unmap("/map/me", returnedhandler)
     self.sortAndAssertSequenceEqual([], self.dispatcher.handlers_for_address("/map/me"))
+
+    # Test with reconstructing handler
+    self.dispatcher.map("/map/me/too", dummyhandler)
+    self.sortAndAssertSequenceEqual([Handler(dummyhandler, [])], self.dispatcher.handlers_for_address("/map/me/too"))
+    self.dispatcher.unmap("/map/me/too", dummyhandler)
+    self.sortAndAssertSequenceEqual([], self.dispatcher.handlers_for_address("/map/me/too"))
 
 if __name__ == "__main__":
   unittest.main()

--- a/pythonosc/test/test_dispatcher.py
+++ b/pythonosc/test/test_dispatcher.py
@@ -121,5 +121,14 @@ class TestDispatcher(unittest.TestCase):
     self.sortAndAssertSequenceEqual(
         [Handler(1, []), Handler(2, [])], self.dispatcher.handlers_for_address("/foo/bar"))
 
+  def test_unmap(self):
+    def dummyhandler():
+        pass
+
+    self.dispatcher.map("/map/me", dummyhandler)
+    self.sortAndAssertSequenceEqual([Handler(dummyhandler, [])], self.dispatcher.handlers_for_address("/map/me"))
+    self.dispatcher.unmap("/map/me", dummyhandler)
+    self.sortAndAssertSequenceEqual([], self.dispatcher.handlers_for_address("/map/me"))
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
I noticed that there was no way to unmap handlers from addresses, so I added one. Comes with unit test.