### PR TITLE
Correct imports on README examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,6 @@ Simple client
   import random
   import time
 
-  from pythonosc import osc_message_builder
   from pythonosc import udp_client
 
 
@@ -130,6 +129,8 @@ Building bundles
 ----------------
 
 .. code-block:: python
+
+    from pythonosc import osc_message_builder
 
     bundle = osc_bundle_builder.OscBundleBuilder(
         osc_bundle_builder.IMMEDIATELY)

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ Building bundles
 
 .. code-block:: python
 
+    from pythonosc import osc_bundle_builder
     from pythonosc import osc_message_builder
 
     bundle = osc_bundle_builder.OscBundleBuilder(


### PR DESCRIPTION
There's no reason to import osc_message_builder in the simple client example, and it was missing from the building bundles examples.