### PR TITLE
Add support for sending NIL value

### DIFF
--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -112,7 +112,7 @@ class OscMessageBuilder(object):
             arg_type = self.ARG_TYPE_MIDI
         elif isinstance(arg_value, list):
             arg_type = [self._get_arg_type(v) for v in arg_value]
-        elif isinstance(arg_value, None):
+        elif arg_value is None:
             arg_type = self.ARG_TYPE_NIL
         else:
             raise ValueError('Infered arg_value type is not supported')
@@ -159,7 +159,8 @@ class OscMessageBuilder(object):
                 elif arg_type in (self.ARG_TYPE_TRUE,
                                   self.ARG_TYPE_FALSE,
                                   self.ARG_TYPE_ARRAY_START,
-                                  self.ARG_TYPE_ARRAY_STOP):
+                                  self.ARG_TYPE_ARRAY_STOP,
+                                  self.ARG_TYPE_NIL):
                     continue
                 else:
                     raise BuildError('Incorrect parameter type found {}'.format(

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -21,13 +21,14 @@ class OscMessageBuilder(object):
     ARG_TYPE_MIDI = "m"
     ARG_TYPE_TRUE = "T"
     ARG_TYPE_FALSE = "F"
+    ARG_TYPE_NIL = "N"
 
     ARG_TYPE_ARRAY_START = "["
     ARG_TYPE_ARRAY_STOP = "]"
 
     _SUPPORTED_ARG_TYPES = (
         ARG_TYPE_FLOAT, ARG_TYPE_DOUBLE, ARG_TYPE_INT, ARG_TYPE_BLOB, ARG_TYPE_STRING,
-        ARG_TYPE_RGBA, ARG_TYPE_MIDI, ARG_TYPE_TRUE, ARG_TYPE_FALSE)
+        ARG_TYPE_RGBA, ARG_TYPE_MIDI, ARG_TYPE_TRUE, ARG_TYPE_FALSE, ARG_TYPE_NIL)
 
     def __init__(self, address: str=None) -> None:
         """Initialize a new builder for a message.
@@ -111,6 +112,8 @@ class OscMessageBuilder(object):
             arg_type = self.ARG_TYPE_MIDI
         elif isinstance(arg_value, list):
             arg_type = [self._get_arg_type(v) for v in arg_value]
+        elif isinstance(arg_value, None):
+            arg_type = self.ARG_TYPE_NIL
         else:
             raise ValueError('Infered arg_value type is not supported')
         return arg_type

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -32,6 +32,7 @@ class TestOscMessageBuilder(unittest.TestCase):
         builder.add_arg(False)
         builder.add_arg(b"\x01\x02\x03")
         builder.add_arg([1, ["abc"]])
+        builder.add_arg(None)
         # The same args but with explicit types.
         builder.add_arg(4.0, builder.ARG_TYPE_FLOAT)
         builder.add_arg(2, builder.ARG_TYPE_INT)
@@ -40,10 +41,11 @@ class TestOscMessageBuilder(unittest.TestCase):
         builder.add_arg(False)
         builder.add_arg(b"\x01\x02\x03", builder.ARG_TYPE_BLOB)
         builder.add_arg([1, ["abc"]], [builder.ARG_TYPE_INT, [builder.ARG_TYPE_STRING]])
+        builder.add_arg(None, builder.ARG_TYPE_NIL)
         builder.add_arg(4278255360, builder.ARG_TYPE_RGBA)
         builder.add_arg((1, 145, 36, 125), builder.ARG_TYPE_MIDI)
         builder.add_arg(1e-9, builder.ARG_TYPE_DOUBLE)
-        self.assertEqual(len("fisTFb[i[s]]") * 2 + 3, len(builder.args))
+        self.assertEqual(len("fisTFb[i[s]]N") * 2 + 3, len(builder.args))
         self.assertEqual("/SYNC", builder.address)
         builder.address = '/SEEK'
         msg = builder.build()

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -51,7 +51,9 @@ class SimpleUDPClient(UDPClient):
             value: One or more arguments to be added to the message
         """
         builder = OscMessageBuilder(address=address)
-        if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
+        if value is None:
+            values = []
+        elif not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
             values = [value]
         else:
             values = value


### PR DESCRIPTION
This would allow the client to send NIL values. The result should be identical to what can be achieved with oscsend: 

    oscsend osc.udp://host:1234 /device/1/2/3

To send such a value, use:

    client.send_message("/device/1/2/3", None)