### PR TITLE
Fix ntp/osc timestamp/timetag conversion and TimedMessage time.

### DIFF
--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -53,7 +53,7 @@ class OscMessage(object):
                 elif param == "m":  # MIDI.
                     val, index = osc_types.get_midi(self._dgram, index)
                 elif param == "t":  # osc time tag:
-                    val, index = osc_types.get_ttag(self._dgram, index)
+                    val, index = osc_types.get_timetag(self._dgram, index)
                 elif param == "T":  # True.
                     val = True
                 elif param == "F":  # False.

--- a/pythonosc/osc_packet.py
+++ b/pythonosc/osc_packet.py
@@ -3,7 +3,6 @@
 It lets you access easily to OscMessage and OscBundle instances in the packet.
 """
 
-import calendar
 import collections
 import time
 
@@ -22,11 +21,11 @@ TimedMessage = collections.namedtuple(
     field_names=('time', 'message'))
 
 
-def _timed_msg_of_bundle(bundle: osc_bundle.OscBundle, now: int) -> List[TimedMessage]:
+def _timed_msg_of_bundle(bundle: osc_bundle.OscBundle, now: float) -> List[TimedMessage]:
     """Returns messages contained in nested bundles as a list of TimedMessage."""
     msgs = []
     for content in bundle:
-        if type(content) == osc_message.OscMessage:
+        if type(content) is osc_message.OscMessage:
             if (bundle.timestamp == osc_types.IMMEDIATELY or bundle.timestamp < now):
                 msgs.append(TimedMessage(now, content))
             else:
@@ -56,7 +55,7 @@ class OscPacket(object):
         Raises:
           - ParseError if the datagram could not be parsed.
         """
-        now = calendar.timegm(time.gmtime())
+        now = time.time()
         try:
             if osc_bundle.OscBundle.dgram_is_bundle(dgram):
                 self._messages = sorted(

--- a/pythonosc/parsing/ntp.py
+++ b/pythonosc/parsing/ntp.py
@@ -6,12 +6,14 @@ import time
 
 from typing import Union
 
-# conversion factor for fractional seconds (maximum value of fractional part)
-FRACTIONAL_CONVERSION = 2 ** 32
 
 # 63 zero bits followed by a one in the least signifigant bit is a special
 # case meaning "immediately."
-IMMEDIATELY = struct.pack('>q', 1)
+IMMEDIATELY = struct.pack('>Q', 1)
+
+# timetag * (1 / 2 ** 32) == l32bits + (r32bits / 1 ** 32)
+_NTP_TIMESTAMP_TO_SECONDS = 1. / 2. ** 32.
+_SECONDS_TO_NTP_TIMESTAMP = 2. ** 32.
 
 # From NTP lib.
 _SYSTEM_EPOCH = datetime.date(*time.gmtime(0)[0:3])
@@ -24,27 +26,33 @@ class NtpError(Exception):
   """Base class for ntp module errors."""
 
 
-def ntp_to_system_time(date: Union[int, float]) -> Union[int, float]:
-    """Convert a NTP time to system time.
-
-    System time is reprensented by seconds since the epoch in UTC.
-    """
-    return date - _NTP_DELTA
-
-def system_time_to_ntp(date: Union[int, float]) -> bytes:
-    """Convert a system time to NTP time.
-
-    System time is reprensented by seconds since the epoch in UTC.
+def ntp_to_system_time(timestamp: bytes) -> float:
+    """Convert a NTP timestamp to system time in seconds.
     """
     try:
-      num_secs = int(date)
+        timestamp = struct.unpack('>Q', timestamp)
+    except Exception as e:
+        raise NtpError(e)
+    return timestamp * _NTP_TIMESTAMP_TO_SECONDS - _NTP_DELTA
+
+
+def system_time_to_ntp(seconds: float) -> bytes:
+    """Convert a system time in seconds to NTP timestamp.
+    """
+    try:
+      seconds = seconds + _NTP_DELTA
     except ValueError as e:
       raise NtpError(e)
-    
-    num_secs_ntp = num_secs + _NTP_DELTA
-    
-    sec_frac = float(date - num_secs)
+    return struct.pack('>Q', int(seconds * _SECONDS_TO_NTP_TIMESTAMP))
 
-    picos = int(sec_frac * FRACTIONAL_CONVERSION)
-  
-    return struct.pack('>I', int(num_secs_ntp)) + struct.pack('>I', picos)
+
+def ntp_time_to_system_epoch(seconds: float) -> float:
+    """Convert a NTP time in seconds to system time in seconds.
+    """
+    return seconds - _NTP_DELTA
+
+
+def system_time_to_ntp_epoch(seconds: float) -> float:
+    """Convert a system time in seconds to NTP time in seconds.
+    """
+    return seconds + _NTP_DELTA

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -169,9 +169,7 @@ def get_timetag(dgram: bytes, start_index: int) -> Tuple[datetime, int]:
             raise ParseError('Datagram is too short')
 
         timetag, _ = get_uint64(dgram, start_index)
-        seconds_float = timetag * ntp._NTP_TIMESTAMP_TO_SECONDS
-        seconds = int(seconds_float)
-        fraction = seconds_float - seconds
+        seconds, fraction = ntp.parse_timestamp(timetag)
 
         hours, seconds = seconds // 3600, seconds % 3600
         minutes, seconds = seconds // 60, seconds % 60

--- a/pythonosc/test/parsing/test_ntp.py
+++ b/pythonosc/test/parsing/test_ntp.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 from pythonosc.parsing import ntp
 
@@ -7,10 +8,13 @@ class TestNTP(unittest.TestCase):
     """ TODO: Write real tests for this when I get time..."""
 
     def test_nto_to_system_time(self):
-        self.assertGreater(0, ntp.ntp_to_system_time(0))
-
-    def test_system_time_to_ntp(self):
-        self.assertTrue(ntp.system_time_to_ntp(0.0))
+        unix_time = time.time()
+        timestamp = ntp.system_time_to_ntp(unix_time)
+        unix_time2 = ntp.ntp_to_system_time(timestamp)
+        self.assertTrue(type(unix_time) is float)
+        self.assertTrue(type(timestamp) is bytes)
+        self.assertTrue(type(unix_time2) is float)
+        self.assertEqual(round(unix_time, 6), round(unix_time2, 6))
 
 
 if __name__ == "__main__":

--- a/pythonosc/test/parsing/test_osc_types.py
+++ b/pythonosc/test/parsing/test_osc_types.py
@@ -160,42 +160,42 @@ class TestMidi(unittest.TestCase):
 
 
 class TestDate(unittest.TestCase):
-    def test_get_ttag(self):
+    def test_get_timetag(self):
         cases = {
-            b"\xde\x9c\x91\xbf\x00\x01\x00\x00": ((datetime(2018, 5, 8, 21, 14, 39), 65536), 8),
+            b"\xde\x9c\x91\xbf\x00\x01\x00\x00": ((datetime(2018, 5, 8, 21, 14, 39), 65536), 8),  # NOTE: fraction is expresed as 32bit OSC.
             b"\x00\x00\x00\x00\x00\x00\x00\x00": ((datetime(1900, 1, 1, 0, 0, 0), 0), 8),
             b"\x83\xaa\x7E\x80\x0A\x00\xB0\x0C": ((datetime(1970, 1, 1, 0, 0, 0), 167817228), 8)
         }
 
         for dgram, expected in cases.items():
-            self.assertEqual(expected, osc_types.get_ttag(dgram, 0))
+            self.assertEqual(expected, osc_types.get_timetag(dgram, 0))
 
-    def test_get_ttag_raises_on_wrong_start_index_negative(self):
+    def test_get_timetag_raises_on_wrong_start_index_negative(self):
         self.assertRaises(
-            osc_types.ParseError, osc_types.get_ttag, b'\x00\x00\x00\x00\x00\x00\x00\x00', -1)
+            osc_types.ParseError, osc_types.get_timetag, b'\x00\x00\x00\x00\x00\x00\x00\x00', -1)
 
-    def test_get_ttag_raises_on_type_error(self):
+    def test_get_timetag_raises_on_type_error(self):
         cases = [b'', True]
 
         for case in cases:
-            self.assertRaises(osc_types.ParseError, osc_types.get_ttag, case, 0)
+            self.assertRaises(osc_types.ParseError, osc_types.get_timetag, case, 0)
 
-    def test_get_ttag_raises_on_wrong_start_index(self):
+    def test_get_timetag_raises_on_wrong_start_index(self):
         self.assertRaises(
             osc_types.ParseError, osc_types.get_date, b'\x00\x00\x00\x11\x00\x00\x00\x11', 1)
 
     def test_ttag_datagram_too_short(self):
         dgram = b'\x00' * 7
-        self.assertRaises(osc_types.ParseError, osc_types.get_ttag, dgram, 6)
+        self.assertRaises(osc_types.ParseError, osc_types.get_timetag, dgram, 6)
 
         dgram = b'\x00' * 2
-        self.assertRaises(osc_types.ParseError, osc_types.get_ttag, dgram, 1)
+        self.assertRaises(osc_types.ParseError, osc_types.get_timetag, dgram, 1)
 
         dgram = b'\x00' * 5
-        self.assertRaises(osc_types.ParseError, osc_types.get_ttag, dgram, 4)
+        self.assertRaises(osc_types.ParseError, osc_types.get_timetag, dgram, 4)
 
         dgram = b'\x00' * 1
-        self.assertRaises(osc_types.ParseError, osc_types.get_ttag, dgram, 0)
+        self.assertRaises(osc_types.ParseError, osc_types.get_timetag, dgram, 0)
 
 
 class TestFloat(unittest.TestCase):
@@ -310,7 +310,9 @@ class TestNTPTimestamp(unittest.TestCase):
         self.assertRaises(osc_types.ParseError, osc_types.get_date, dgram, 2)
 
     def test_write_date(self):
-        self.assertEqual(b'\x83\xaa~\x83\":)\xc7', osc_types.write_date(3.1337))
+        time = 1569899476.167749  # known round(time.time(), 6)
+        timetag = b'\xe1=BT*\xf1\x98\x00'
+        self.assertEqual(timetag, osc_types.write_date(time))
 
 
 class TestBuildMethods(unittest.TestCase):


### PR DESCRIPTION
Hi

OSC timetag conversion was broken. This PR solves that problem and TimedMessage not being scheduled from bundles by Dispatcher.call_handlers_for_packet().

I did change some names to make them more meaningful (at least for me). If that is not acceptable you can still take the timing fix from this patch and have my approval.