### PR TITLE
In python 3.8, Iterable must be imported from collections.abc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 script: python setup.py test

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -2,7 +2,7 @@
 
 try:
     from collections.abc import Iterable
-catch ImportError: # python 3.5
+except ImportError: # python 3.5
     from collections import Iterable
     
 import socket

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -1,6 +1,6 @@
 """UDP Clients for sending OSC messages to an OSC server"""
 
-from collections import Iterable
+from collections.abc import Iterable
 import socket
 
 from .osc_message_builder import OscMessageBuilder

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -1,6 +1,10 @@
 """UDP Clients for sending OSC messages to an OSC server"""
 
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+catch ImportError: # python 3.5
+    from collections import Iterable
+    
 import socket
 
 from .osc_message_builder import OscMessageBuilder


### PR DESCRIPTION
Switch from deprecated `from collections import Iterable` to `from collections.abc import Iterable` for python 3.8 support.