### PR TITLE
Add Int64 support (OSC Type h)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-No changes so far
+### Added
+
+- Support for sending and receiving Int64 datatype (`h`).
 
 ## [1.7.7]
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Features
 
 * UDP blocking/threading/forking/asyncio server implementations
 * UDP client
-* int, float, string, double, MIDI, timestamps, blob OSC arguments
+* int, int64, float, string, double, MIDI, timestamps, blob OSC arguments
 * simple OSC address<->callback matching system
 * extensive unit test coverage
 * basic client and server examples

--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -40,6 +40,8 @@ class OscMessage(object):
             for param in type_tag:
                 if param == "i":  # Integer.
                     val, index = osc_types.get_int(self._dgram, index)
+                elif param == "h":  # Int64.
+                    val, index = osc_types.get_int64(self._dgram, index)
                 elif param == "f":  # Float.
                     val, index = osc_types.get_float(self._dgram, index)
                 elif param == "d":  # Double.

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -15,6 +15,7 @@ class OscMessageBuilder(object):
     ARG_TYPE_FLOAT = "f"
     ARG_TYPE_DOUBLE = "d"
     ARG_TYPE_INT = "i"
+    ARG_TYPE_INT64 = "h"
     ARG_TYPE_STRING = "s"
     ARG_TYPE_BLOB = "b"
     ARG_TYPE_RGBA = "r"
@@ -27,7 +28,7 @@ class OscMessageBuilder(object):
     ARG_TYPE_ARRAY_STOP = "]"
 
     _SUPPORTED_ARG_TYPES = (
-        ARG_TYPE_FLOAT, ARG_TYPE_DOUBLE, ARG_TYPE_INT, ARG_TYPE_BLOB, ARG_TYPE_STRING,
+        ARG_TYPE_FLOAT, ARG_TYPE_DOUBLE, ARG_TYPE_INT, ARG_TYPE_INT64, ARG_TYPE_BLOB, ARG_TYPE_STRING,
         ARG_TYPE_RGBA, ARG_TYPE_MIDI, ARG_TYPE_TRUE, ARG_TYPE_FALSE, ARG_TYPE_NIL)
 
     def __init__(self, address: str=None) -> None:
@@ -105,7 +106,10 @@ class OscMessageBuilder(object):
         elif arg_value is False:
             arg_type = self.ARG_TYPE_FALSE
         elif isinstance(arg_value, int):
-            arg_type = self.ARG_TYPE_INT
+            if arg_value.bit_length() > 32:
+                arg_type = self.ARG_TYPE_INT64
+            else:
+                arg_type = self.ARG_TYPE_INT
         elif isinstance(arg_value, float):
             arg_type = self.ARG_TYPE_FLOAT
         elif isinstance(arg_value, tuple) and len(arg_value) == 4:
@@ -146,6 +150,8 @@ class OscMessageBuilder(object):
                     dgram += osc_types.write_string(value)
                 elif arg_type == self.ARG_TYPE_INT:
                     dgram += osc_types.write_int(value)
+                elif arg_type == self.ARG_TYPE_INT64:
+                    dgram += osc_types.write_int64(value)
                 elif arg_type == self.ARG_TYPE_FLOAT:
                     dgram += osc_types.write_float(value)
                 elif arg_type == self.ARG_TYPE_DOUBLE:

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -21,6 +21,7 @@ IMMEDIATELY = 0
 
 # Datagram length in bytes for types that have a fixed size.
 _INT_DGRAM_LEN = 4
+_INT64_DGRAM_LEN = 8
 _UINT64_DGRAM_LEN = 8
 _FLOAT_DGRAM_LEN = 4
 _DOUBLE_DGRAM_LEN = 8
@@ -122,6 +123,42 @@ def get_int(dgram: bytes, start_index: int) -> Tuple[int, int]:
             struct.unpack('>i',
                           dgram[start_index:start_index + _INT_DGRAM_LEN])[0],
             start_index + _INT_DGRAM_LEN)
+    except (struct.error, TypeError) as e:
+        raise ParseError('Could not parse datagram %s' % e)
+
+
+def write_int64(val: int) -> bytes:
+    """Returns the datagram for the given 64-bit big-endian signed parameter value
+
+    Raises:
+      - BuildError if the int64 could not be converted.
+    """
+    try:
+        return struct.pack('>q', val)
+    except struct.error as e:
+        raise BuildError('Wrong argument value passed: {}'.format(e))
+
+
+def get_int64(dgram: bytes, start_index: int) -> Tuple[int, int]:
+    """Get a 64-bit big-endian signed integer from the datagram.
+
+    Args:
+      dgram: A datagram packet.
+      start_index: An index where the 64-bit integer starts in the datagram.
+
+    Returns:
+      A tuple containing the 64-bit integer and the new end index.
+
+    Raises:
+      ParseError if the datagram could not be parsed.
+    """
+    try:
+        if len(dgram[start_index:]) < _INT64_DGRAM_LEN:
+            raise ParseError('Datagram is too short')
+        return (
+            struct.unpack('>q',
+                          dgram[start_index:start_index + _INT64_DGRAM_LEN])[0],
+            start_index + _INT64_DGRAM_LEN)
     except (struct.error, TypeError) as e:
         raise ParseError('Could not parse datagram %s' % e)
 

--- a/pythonosc/test/test_osc_message.py
+++ b/pythonosc/test/test_osc_message.py
@@ -34,8 +34,9 @@ _DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS = (
     b"/SYNC\x00\x00\x00"
     b"T"  # True
     b"F"  # False
-    b"[]\x00\x00\x00"  # Empty array
-    b"t\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"[]th\x00\x00"  # Empty array
+    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\xe8\xd4\xa5\x10\x00"  # 1000000000000
 )
 
 _DGRAM_COMPLEX_ARRAY_PARAMS = (
@@ -99,12 +100,13 @@ class TestOscMessage(unittest.TestCase):
         msg = osc_message.OscMessage(_DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS)
 
         self.assertEqual("/SYNC", msg.address)
-        self.assertEqual(4, len(msg.params))
+        self.assertEqual(5, len(msg.params))
         self.assertEqual(True, msg.params[0])
         self.assertEqual(False, msg.params[1])
         self.assertEqual([], msg.params[2])
         self.assertEqual((datetime(1900, 1, 1, 0, 0, 0), 0), msg.params[3])
-        self.assertEqual(4, len(list(msg)))
+        self.assertEqual(1000000000000, msg.params[4])
+        self.assertEqual(5, len(list(msg)))
 
     def test_complex_array_params(self):
         msg = osc_message.OscMessage(_DGRAM_COMPLEX_ARRAY_PARAMS)

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -27,6 +27,7 @@ class TestOscMessageBuilder(unittest.TestCase):
         builder = osc_message_builder.OscMessageBuilder(address="/SYNC")
         builder.add_arg(4.0)
         builder.add_arg(2)
+        builder.add_arg(1099511627776)
         builder.add_arg("value")
         builder.add_arg(True)
         builder.add_arg(False)
@@ -36,6 +37,7 @@ class TestOscMessageBuilder(unittest.TestCase):
         # The same args but with explicit types.
         builder.add_arg(4.0, builder.ARG_TYPE_FLOAT)
         builder.add_arg(2, builder.ARG_TYPE_INT)
+        builder.add_arg(1099511627776, builder.ARG_TYPE_INT64)
         builder.add_arg("value", builder.ARG_TYPE_STRING)
         builder.add_arg(True)
         builder.add_arg(False)
@@ -45,13 +47,13 @@ class TestOscMessageBuilder(unittest.TestCase):
         builder.add_arg(4278255360, builder.ARG_TYPE_RGBA)
         builder.add_arg((1, 145, 36, 125), builder.ARG_TYPE_MIDI)
         builder.add_arg(1e-9, builder.ARG_TYPE_DOUBLE)
-        self.assertEqual(len("fisTFb[i[s]]N") * 2 + 3, len(builder.args))
+        self.assertEqual(len("fihsTFb[i[s]]N") * 2 + 3, len(builder.args))
         self.assertEqual("/SYNC", builder.address)
         builder.address = '/SEEK'
         msg = builder.build()
         self.assertEqual("/SEEK", msg.address)
         self.assertSequenceEqual(
-            [4.0, 2, "value", True, False, b"\x01\x02\x03", [1, ["abc"]]] * 2 +
+            [4.0, 2, 1099511627776, "value", True, False, b"\x01\x02\x03", [1, ["abc"]]] * 2 +
             [4278255360, (1, 145, 36, 125), 1e-9],
             msg.params)
 


### PR DESCRIPTION
I have implemented the long requested Int64 support in #21 . I followed the code style of the `UInt64` and `Integer` implementation.

Here is an example script to test it, unit tests are implemented as well.

```python
import threading
import time

from pythonosc.dispatcher import Dispatcher
from pythonosc.osc_message_builder import OscMessageBuilder
from pythonosc.udp_client import SimpleUDPClient
from pythonosc import osc_server

HOST = "127.0.0.1"
PORT = 7500
ADDRESS = "/test"


def start_listener():
    dispatcher = Dispatcher()
    dispatcher.map(ADDRESS, print)

    server = osc_server.ThreadingOSCUDPServer(
        (HOST, PORT), dispatcher)
    print("Serving on {}".format(server.server_address))
    server.serve_forever()


def main():
    threading.Thread(target=start_listener).start()

    sender = SimpleUDPClient(HOST, PORT)
    running = True
    while running:
        builder = OscMessageBuilder(address=ADDRESS)

        # add integer with type inference
        builder.add_arg(5000)

        # add integer with explicit type
        builder.add_arg(32003, arg_type=OscMessageBuilder.ARG_TYPE_INT)

        # add integer at upper limit
        builder.add_arg(pow(2, 32))

        # add int64 with type inference
        builder.add_arg(pow(2, 40))

        # add int64 with explicit type
        builder.add_arg(34359738368, arg_type=OscMessageBuilder.ARG_TYPE_INT64)

        # epoch time with type inference
        builder.add_arg(time.time_ns() // 1_000_000)

        sender.send(builder.build())

        time.sleep(0.5)


if __name__ == "__main__":
    main()

```
