### PR TITLE
Indicate that this is a typed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE.txt
+include pythonosc/py.typed


### PR DESCRIPTION
This allows type checkers to make use of the types from this package when validating consuming code.

Fixes https://github.com/attwad/python-osc/issues/155