### PR TITLE
Add type checking in CI and fixup annotations

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -35,6 +35,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Check with mypy
+      run: |
+        mypy pythonosc examples
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,6 +37,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Check with mypy
       run: |
+        pip install pygame   # Needed for examples
         mypy pythonosc examples
     - name: Test with pytest
       run: |

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Simple server
   import argparse
   import math
 
-  from pythonosc import dispatcher
+  from pythonosc.dispatcher import Dispatcher
   from pythonosc import osc_server
 
   def print_volume_handler(unused_addr, args, volume):
@@ -116,7 +116,7 @@ Simple server
         type=int, default=5005, help="The port to listen on")
     args = parser.parse_args()
 
-    dispatcher = dispatcher.Dispatcher()
+    dispatcher = Dispatcher()
     dispatcher.map("/filter", print)
     dispatcher.map("/volume", print_volume_handler, "Volume")
     dispatcher.map("/logvolume", print_compute_handler, "Log volume", math.log)

--- a/examples/async_server.py
+++ b/examples/async_server.py
@@ -1,3 +1,4 @@
+import sys
 from pythonosc.osc_server import AsyncIOOSCUDPServer
 from pythonosc.dispatcher import Dispatcher
 import asyncio
@@ -30,4 +31,10 @@ async def init_main():
     transport.close()  # Clean up serve endpoint
 
 
-asyncio.run(init_main())
+if sys.version_info >= (3, 7):
+    asyncio.run(init_main())
+else:
+    # TODO(python-upgrade): drop this once 3.6 is no longer supported
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(init_main())
+    event_loop.close()

--- a/examples/reaktor_lazerbass.py
+++ b/examples/reaktor_lazerbass.py
@@ -5,6 +5,8 @@ import multiprocessing
 import queue
 import logging
 
+from typing import Tuple
+
 from pygame.constants import QUIT
 
 from pythonosc.dispatcher import Dispatcher
@@ -88,13 +90,13 @@ if __name__ == "__main__":
 
     # client = udp_client.UDPClient(args.client_ip, args.client_port)
 
-    bq = multiprocessing.Queue()
+    bq = multiprocessing.Queue()  # type: multiprocessing.Queue[Tuple[str, float]]
     reaktor = ReaktorDisplay(bq)
 
 
     def put_in_queue(args, value):
         """Put a named argument in the queue to be able to use a single queue."""
-        bq.put([args[0], value])
+        bq.put((args[0], value))
 
 
     dispatcher = Dispatcher()

--- a/examples/reaktor_lazerbass.py
+++ b/examples/reaktor_lazerbass.py
@@ -7,7 +7,7 @@ import logging
 
 from pygame.constants import QUIT
 
-from pythonosc import dispatcher
+from pythonosc.dispatcher import Dispatcher
 from pythonosc import osc_server
 
 logging.basicConfig(
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         bq.put([args[0], value])
 
 
-    dispatcher = dispatcher.Dispatcher()
+    dispatcher = Dispatcher()
     dispatcher.map("/debug", logging.debug)
     dispatcher.map("/beating", put_in_queue, "beating")
     dispatcher.map("/blocks", put_in_queue, "blocks")

--- a/examples/reaktor_lazerbass.py
+++ b/examples/reaktor_lazerbass.py
@@ -5,7 +5,7 @@ import multiprocessing
 import queue
 import logging
 
-from pygame.locals import *
+from pygame.constants import QUIT
 
 from pythonosc import dispatcher
 from pythonosc import osc_server

--- a/examples/simple_2way.py
+++ b/examples/simple_2way.py
@@ -11,7 +11,7 @@ import math
 import threading
 
 from pythonosc import udp_client
-from pythonosc import dispatcher
+from pythonosc.dispatcher import Dispatcher
 from pythonosc import osc_server
 
 
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
 
     # listen to addresses and print changes in values 
-    dispatcher = dispatcher.Dispatcher()
+    dispatcher = Dispatcher()
     dispatcher.map("/1/push2", print)
     dispatcher.map("/1/fader1", print_fader_handler, "Focus")
     dispatcher.map("/1/fader2", print_fader_handler, "Zoom")

--- a/examples/simple_server.py
+++ b/examples/simple_server.py
@@ -6,7 +6,7 @@ received packets.
 import argparse
 import math
 
-from pythonosc import dispatcher
+from pythonosc.dispatcher import Dispatcher
 from pythonosc import osc_server
 
 
@@ -29,7 +29,7 @@ if __name__ == "__main__":
                         type=int, default=5005, help="The port to listen on")
     args = parser.parse_args()
 
-    dispatcher = dispatcher.Dispatcher()
+    dispatcher = Dispatcher()
     dispatcher.map("/filter", print)
     dispatcher.map("/volume", print_volume_handler, "Volume")
     dispatcher.map("/logvolume", print_compute_handler, "Log volume", math.log)

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -6,7 +6,7 @@ import logging
 import re
 import time
 from pythonosc import osc_packet
-from typing import overload, List, Union, Any, Generator, Tuple, Callable
+from typing import overload, List, Union, Any, Generator, Tuple, Callable, Optional, DefaultDict
 from pythonosc.osc_message import OscMessage
 
 
@@ -31,13 +31,13 @@ class Handler(object):
         self.needs_reply_address = _needs_reply_address
 
     # needed for test module
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         return (type(self) == type(other) and
                 self.callback == other.callback and
                 self.args == other.args and
                 self.needs_reply_address == other.needs_reply_address)
 
-    def invoke(self, client_address: str, message: OscMessage) -> None:
+    def invoke(self, client_address: Tuple[str, int], message: OscMessage) -> None:
         """Invokes the associated callback function
 
         Args:
@@ -63,8 +63,8 @@ class Dispatcher(object):
     """
 
     def __init__(self) -> None:
-        self._map = collections.defaultdict(list)
-        self._default_handler = None
+        self._map = collections.defaultdict(list)  # type: DefaultDict[str, List[Handler]]
+        self._default_handler = None  # type: Optional[Handler]
 
     def map(self, address: str, handler: Callable, *args: Union[Any, List[Any]],
             needs_reply_address: bool = False) -> Handler:

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -6,8 +6,7 @@ import logging
 import re
 import time
 from pythonosc import osc_packet
-from typing import overload, List, Union, Any, Generator, Tuple
-from types import FunctionType
+from typing import overload, List, Union, Any, Generator, Tuple, Callable
 from pythonosc.osc_message import OscMessage
 
 
@@ -19,7 +18,7 @@ class Handler(object):
     message if any were passed.
     """
 
-    def __init__(self, _callback: FunctionType, _args: Union[Any, List[Any]],
+    def __init__(self, _callback: Callable, _args: Union[Any, List[Any]],
                  _needs_reply_address: bool = False) -> None:
         """
         Args:
@@ -67,7 +66,7 @@ class Dispatcher(object):
         self._map = collections.defaultdict(list)
         self._default_handler = None
 
-    def map(self, address: str, handler: FunctionType, *args: Union[Any, List[Any]],
+    def map(self, address: str, handler: Callable, *args: Union[Any, List[Any]],
             needs_reply_address: bool = False) -> Handler:
         """Map an address to a handler
 
@@ -108,7 +107,7 @@ class Dispatcher(object):
         pass
 
     @overload
-    def unmap(self, address: str, handler: FunctionType, *args: Union[Any, List[Any]],
+    def unmap(self, address: str, handler: Callable, *args: Union[Any, List[Any]],
               needs_reply_address: bool = False) -> None:
         """Remove an already mapped handler from an address
 
@@ -195,7 +194,7 @@ class Dispatcher(object):
         except osc_packet.ParseError:
             pass
 
-    def set_default_handler(self, handler: FunctionType, needs_reply_address: bool = False) -> None:
+    def set_default_handler(self, handler: Callable, needs_reply_address: bool = False) -> None:
         """Sets the default handler
 
         The default handler is invoked every time no other handler is mapped to an address.

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -133,7 +133,7 @@ class Dispatcher(object):
             if str(e) == "list.remove(x): x not in list":
                 raise ValueError("Address '%s' doesn't have handler '%s' mapped to it" % (address, handler)) from e
 
-    def handlers_for_address(self, address_pattern: str) -> Generator[None, Handler, None]:
+    def handlers_for_address(self, address_pattern: str) -> Generator[Handler, None, None]:
         """Yields handlers matching an address
 
 

--- a/pythonosc/osc_bundle.py
+++ b/pythonosc/osc_bundle.py
@@ -3,7 +3,7 @@ import logging
 from pythonosc import osc_message
 from pythonosc.parsing import osc_types
 
-from typing import Any, Iterator
+from typing import Any, Iterator, List, Union
 
 _BUNDLE_PREFIX = b"#bundle\x00"
 
@@ -37,10 +37,8 @@ class OscBundle(object):
         # Get the contents as a list of OscBundle and OscMessage.
         self._contents = self._parse_contents(index)
 
-    # Return type is actually List[OscBundle], but that would require import annotations from __future__, which is
-    # python 3.7+ only.
-    def _parse_contents(self, index: int) -> Any:
-        contents = []
+    def _parse_contents(self, index: int) -> List[Union['OscBundle', osc_message.OscMessage]]:
+        contents = []  # type: List[Union[OscBundle, osc_message.OscMessage]]
 
         try:
             # An OSC Bundle Element consists of its size and its contents.

--- a/pythonosc/osc_bundle.py
+++ b/pythonosc/osc_bundle.py
@@ -73,7 +73,7 @@ class OscBundle(object):
         return dgram.startswith(_BUNDLE_PREFIX)
 
     @property
-    def timestamp(self) -> int:
+    def timestamp(self) -> float:
         """Returns the timestamp associated with this bundle."""
         return self._timestamp
 

--- a/pythonosc/osc_bundle.py
+++ b/pythonosc/osc_bundle.py
@@ -90,7 +90,7 @@ class OscBundle(object):
         """Returns the datagram from which this bundle was built."""
         return self._dgram
 
-    def content(self, index) -> Any:
+    def content(self, index: int) -> Any:
         """Returns the bundle's content 0-indexed."""
         return self._contents[index]
 

--- a/pythonosc/osc_bundle.py
+++ b/pythonosc/osc_bundle.py
@@ -59,7 +59,7 @@ class OscBundle(object):
                     contents.append(osc_message.OscMessage(content_dgram))
                 else:
                     logging.warning(
-                        "Could not identify content type of dgram %s" % content_dgram)
+                        "Could not identify content type of dgram %r" % content_dgram)
         except (osc_types.ParseError, osc_message.ParseError, IndexError) as e:
             raise ParseError("Could not parse a content datagram: %s" % e)
 

--- a/pythonosc/osc_bundle_builder.py
+++ b/pythonosc/osc_bundle_builder.py
@@ -1,5 +1,7 @@
 """Build OSC bundles for client applications."""
 
+from typing import List
+
 from pythonosc import osc_bundle
 from pythonosc import osc_message
 from pythonosc.parsing import osc_types
@@ -23,7 +25,7 @@ class OscBundleBuilder(object):
                        seconds since the epoch in UTC or IMMEDIATELY.
         """
         self._timestamp = timestamp
-        self._contents = []
+        self._contents = []  # type: List[osc_bundle.OscBundle]
 
     def add_content(self, content: osc_bundle.OscBundle) -> None:
         """Add a new content to this bundle.

--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -19,7 +19,7 @@ class OscMessage(object):
 
     def __init__(self, dgram: bytes) -> None:
         self._dgram = dgram
-        self._parameters = []
+        self._parameters = []  # type: List[Any]
         self._parse_datagram()
 
     def _parse_datagram(self) -> None:
@@ -34,10 +34,11 @@ class OscMessage(object):
             if type_tag.startswith(','):
                 type_tag = type_tag[1:]
 
-            params = []
+            params = []  # type: List[Any]
             param_stack = [params]
             # Parse each parameter given its type.
             for param in type_tag:
+                val = NotImplemented  # type: Any
                 if param == "i":  # Integer.
                     val, index = osc_types.get_int(self._dgram, index)
                 elif param == "h":  # Int64.
@@ -61,7 +62,7 @@ class OscMessage(object):
                 elif param == "F":  # False.
                     val = False
                 elif param == "[":  # Array start.
-                    array = []
+                    array = []  # type: List[Any]
                     param_stack[-1].append(array)
                     param_stack.append(array)
                 elif param == "]":  # Array stop.
@@ -105,6 +106,6 @@ class OscMessage(object):
         """Convenience method for list(self) to get the list of parameters."""
         return list(self)
 
-    def __iter__(self) -> Iterator[float]:
+    def __iter__(self) -> Iterator[Any]:
         """Returns an iterator over the parameters of this message."""
         return iter(self._parameters)

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -3,7 +3,7 @@
 from pythonosc import osc_message
 from pythonosc.parsing import osc_types
 
-from typing import List, Tuple, Union, Any
+from typing import List, Tuple, Union, Any, Optional
 
 
 ArgValue = Union[str, bytes, bool, int, float, osc_types.MidiPacket, list]
@@ -45,7 +45,7 @@ class OscMessageBuilder(object):
         self._args = []  # type: List[Tuple[str, Union[ArgValue, None]]]
 
     @property
-    def address(self) -> str:
+    def address(self) -> Optional[str]:
         """Returns the OSC address this message will be sent to."""
         return self._address
 

--- a/pythonosc/osc_packet.py
+++ b/pythonosc/osc_packet.py
@@ -3,22 +3,22 @@
 It lets you access easily to OscMessage and OscBundle instances in the packet.
 """
 
-import collections
 import time
 
 from pythonosc.parsing import osc_types
 from pythonosc import osc_bundle
 from pythonosc import osc_message
 
-from typing import Union, List
+from typing import Union, List, NamedTuple
 
 # A namedtuple as returned my the _timed_msg_of_bundle function.
 # 1) the system time at which the message should be executed
 #    in seconds since the epoch.
 # 2) the actual message.
-TimedMessage = collections.namedtuple(
-    typename='TimedMessage',
-    field_names=('time', 'message'))
+TimedMessage = NamedTuple('TimedMessage', [
+    ('time', float),
+    ('message', osc_message.OscMessage),
+])
 
 
 def _timed_msg_of_bundle(bundle: osc_bundle.OscBundle, now: float) -> List[TimedMessage]:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -12,8 +12,7 @@ from pythonosc.dispatcher import Dispatcher
 from asyncio import BaseEventLoop
 
 from socket import socket as _socket
-from typing import Tuple, Union, cast
-from types import coroutine
+from typing import Any, Tuple, Union, cast, Coroutine
 
 _RequestType = Union[_socket, Tuple[bytes, _socket]]
 _AddressType = Union[Tuple[str, int], str]
@@ -142,7 +141,7 @@ class AsyncIOOSCUDPServer():
         """
         self._loop.run_until_complete(self.create_serve_endpoint())
 
-    def create_serve_endpoint(self) -> coroutine:
+    def create_serve_endpoint(self) -> Coroutine[Any, Any, Tuple[asyncio.transports.BaseTransport, asyncio.DatagramProtocol]]:
         """Creates a datagram endpoint and registers it with event loop as coroutine.
 
         Returns:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -58,7 +58,7 @@ class OSCUDPServer(socketserver.UDPServer):
             dispatcher: Dispatcher this server will use
             (optional) bind_and_activate: default=True defines if the server has to start on call of constructor  
         """
-        super().__init__(server_address, _UDPHandler, bind_and_activate)
+        super().__init__(server_address, _UDPHandler, bind_and_activate)  # type: ignore[call-arg]  # https://github.com/python/typeshed/pull/8542
         self._dispatcher = dispatcher
 
     def verify_request(self, request: _RequestType, client_address: _AddressType) -> bool:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -50,7 +50,7 @@ def _is_valid_request(request: _RequestType) -> bool:
 class OSCUDPServer(socketserver.UDPServer):
     """Superclass for different flavors of OSC UDP servers"""
 
-    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate=True) -> None:
+    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate: bool = True) -> None:
         """Initialize
 
         Args:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -12,7 +12,7 @@ from pythonosc.dispatcher import Dispatcher
 from asyncio import BaseEventLoop
 
 from socket import socket as _socket
-from typing import Tuple, Union
+from typing import Tuple, Union, cast
 from types import coroutine
 
 _RequestType = Union[_socket, Tuple[bytes, _socket]]
@@ -30,7 +30,8 @@ class _UDPHandler(socketserver.BaseRequestHandler):
         If not the server won't call it and so no new
         threads/processes will be spawned.
         """
-        self.server.dispatcher.call_handlers_for_packet(self.request[0], self.client_address)
+        server = cast(OSCUDPServer, self.server)
+        server.dispatcher.call_handlers_for_packet(self.request[0], self.client_address)
 
 
 def _is_valid_request(request: _RequestType) -> bool:

--- a/pythonosc/parsing/ntp.py
+++ b/pythonosc/parsing/ntp.py
@@ -3,8 +3,8 @@
 import datetime
 import struct
 import time
-import collections
 
+from typing import NamedTuple
 
 # 63 zero bits followed by a one in the least signifigant bit is a special
 # case meaning "immediately."
@@ -21,9 +21,10 @@ _NTP_EPOCH = datetime.date(1900, 1, 1)
 _NTP_DELTA = (_SYSTEM_EPOCH - _NTP_EPOCH).days * 24 * 3600
 
 
-Timestamp = collections.namedtuple(
-    typename='Timetag',
-    field_names=('seconds', 'fraction'))
+Timestamp = NamedTuple('Timestamp', [
+    ('seconds', int),
+    ('fraction', int),
+])
 
 
 class NtpError(Exception):

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -5,7 +5,7 @@ import struct
 from pythonosc.parsing import ntp
 from datetime import datetime, timedelta, date
 
-from typing import Union, Tuple
+from typing import Union, Tuple, cast
 
 
 class ParseError(Exception):
@@ -447,7 +447,9 @@ def get_midi(dgram: bytes, start_index: int) -> Tuple[Tuple[int, int, int, int],
             raise ParseError('Datagram is too short')
         val = struct.unpack('>I',
                             dgram[start_index:start_index + _INT_DGRAM_LEN])[0]
-        midi_msg = tuple((val & 0xFF << 8 * i) >> 8 * i for i in range(3, -1, -1))
+        midi_msg = cast(
+            Tuple[int, int, int, int],
+            tuple((val & 0xFF << 8 * i) >> 8 * i for i in range(3, -1, -1)))
         return (midi_msg, start_index + _INT_DGRAM_LEN)
     except (struct.error, TypeError) as e:
         raise ParseError('Could not parse datagram %s' % e)

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -413,7 +413,7 @@ def get_rgba(dgram: bytes, start_index: int) -> Tuple[bytes, int]:
         raise ParseError('Could not parse datagram %s' % e)
 
 
-def write_midi(val: Tuple[MidiPacket, int]) -> bytes:
+def write_midi(val: MidiPacket) -> bytes:
     """Returns the datagram for the given MIDI message parameter value
 
        A valid MIDI message: (port id, status byte, data1, data2).

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, date
 
 from typing import Union, Tuple, cast
 
+MidiPacket = Tuple[int, int, int, int]
+
 
 class ParseError(Exception):
     """Base exception for when a datagram parsing error occurs."""
@@ -411,7 +413,7 @@ def get_rgba(dgram: bytes, start_index: int) -> Tuple[bytes, int]:
         raise ParseError('Could not parse datagram %s' % e)
 
 
-def write_midi(val: Tuple[Tuple[int, int, int, int], int]) -> bytes:
+def write_midi(val: Tuple[MidiPacket, int]) -> bytes:
     """Returns the datagram for the given MIDI message parameter value
 
        A valid MIDI message: (port id, status byte, data1, data2).
@@ -429,7 +431,7 @@ def write_midi(val: Tuple[Tuple[int, int, int, int], int]) -> bytes:
         raise BuildError('Wrong argument value passed: {}'.format(e))
 
 
-def get_midi(dgram: bytes, start_index: int) -> Tuple[Tuple[int, int, int, int], int]:
+def get_midi(dgram: bytes, start_index: int) -> Tuple[MidiPacket, int]:
     """Get a MIDI message (port id, status byte, data1, data2) from the datagram.
 
     Args:
@@ -448,7 +450,7 @@ def get_midi(dgram: bytes, start_index: int) -> Tuple[Tuple[int, int, int, int],
         val = struct.unpack('>I',
                             dgram[start_index:start_index + _INT_DGRAM_LEN])[0]
         midi_msg = cast(
-            Tuple[int, int, int, int],
+            MidiPacket,
             tuple((val & 0xFF << 8 * i) >> 8 * i for i in range(3, -1, -1)))
         return (midi_msg, start_index + _INT_DGRAM_LEN)
     except (struct.error, TypeError) as e:

--- a/pythonosc/parsing/osc_types.py
+++ b/pythonosc/parsing/osc_types.py
@@ -187,7 +187,7 @@ def get_uint64(dgram: bytes, start_index: int) -> Tuple[int, int]:
         raise ParseError('Could not parse datagram %s' % e)
 
 
-def get_timetag(dgram: bytes, start_index: int) -> Tuple[datetime, int]:
+def get_timetag(dgram: bytes, start_index: int) -> Tuple[Tuple[datetime, int], int]:
     """Get a 64-bit OSC time tag from the datagram.
 
     Args:

--- a/pythonosc/test/test_osc_server.py
+++ b/pythonosc/test/test_osc_server.py
@@ -18,11 +18,11 @@ _SIMPLE_MSG_NO_PARAMS = b"/SYNC\x00\x00\x00"
 class TestOscServer(unittest.TestCase):
     def test_is_valid_request(self):
         self.assertTrue(
-            osc_server._is_valid_request([b'#bundle\x00foobar']))
+            osc_server._is_valid_request((b'#bundle\x00foobar',)))
         self.assertTrue(
-            osc_server._is_valid_request([b'/address/1/2/3,foobar']))
+            osc_server._is_valid_request((b'/address/1/2/3,foobar',)))
         self.assertFalse(
-            osc_server._is_valid_request([b'']))
+            osc_server._is_valid_request((b'',)))
 
 
 class TestUDPHandler(unittest.TestCase):

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -37,7 +37,7 @@ class UDPClient(object):
                 continue
             break
 
-        self._sock.setblocking(0)
+        self._sock.setblocking(False)
         if allow_broadcast:
             self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         self._address = address

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -4,10 +4,10 @@ try:
     from collections.abc import Iterable
 except ImportError: # python 3.5
     from collections import Iterable
-    
+
 import socket
 
-from .osc_message_builder import OscMessageBuilder
+from .osc_message_builder import OscMessageBuilder, ArgValue
 from pythonosc.osc_message import OscMessage
 from pythonosc.osc_bundle import OscBundle
 
@@ -55,7 +55,7 @@ class UDPClient(object):
 class SimpleUDPClient(UDPClient):
     """Simple OSC client that automatically builds :class:`OscMessage` from arguments"""
 
-    def send_message(self, address: str, value: Union[int, float, bytes, str, bool, tuple, list]) -> None:
+    def send_message(self, address: str, value: ArgValue) -> None:
         """Build :class:`OscMessage` from arguments and send to server
 
         Args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,35 @@
 [metadata]
 license_files = LICENSE.txt
+
+[mypy]
+# Would be great to turn this on, however there's too many cases it would break
+# right now.
+# disallow_any_generics = True
+
+disallow_subclassing_any = True
+
+# Allow functions _without_ type annotations, but require that annotations be
+# complete (possibly including the `Any` type) where they are present.
+disallow_incomplete_defs = True
+# check_untyped_defs = True
+disallow_untyped_decorators = True
+
+
+# # Would be great to turn these on eventually
+# no_implicit_optional = True
+# strict_optional = True
+
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True
+# # Would be great to turn this on eventually
+# # warn_return_any = True
+# warn_unreachable = True
+
+# implicit_reexport = False
+# strict_equality = True
+
+scripts_are_modules = True
+warn_unused_configs = True
+
+enable_error_code = ignore-without-code


### PR DESCRIPTION
This adds type checking in CI with `mypy`, a basic configuration for `mypy` and fixes the errors that are found.

The configuration is very nearly the default and mostly doesn't enable additional checks. The checks which are enabled are mostly to guide future usage in the right direction.

The fixes here are intended to be as minimal as possible and are derived from code inspection. I've run the tests, but don't have an actual deployment to test this with manually.