### PR TITLE
Add support for arguments with Nil type

### DIFF
--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -61,6 +61,8 @@ class OscMessage(object):
                     val = True
                 elif param == "F":  # False.
                     val = False
+                elif param == "N":  # Nil.
+                    val = None
                 elif param == "[":  # Array start.
                     array = []  # type: List[Any]
                     param_stack[-1].append(array)

--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -5,13 +5,10 @@ from pythonosc.parsing import osc_types
 
 from typing import List, Tuple, Union, Any, Optional
 
-
 ArgValue = Union[str, bytes, bool, int, float, osc_types.MidiPacket, list]
-
 
 class BuildError(Exception):
     """Error raised when an incomplete message is trying to be built."""
-
 
 class OscMessageBuilder(object):
     """Builds arbitrary OscMessage instances."""
@@ -35,7 +32,7 @@ class OscMessageBuilder(object):
         ARG_TYPE_FLOAT, ARG_TYPE_DOUBLE, ARG_TYPE_INT, ARG_TYPE_INT64, ARG_TYPE_BLOB, ARG_TYPE_STRING,
         ARG_TYPE_RGBA, ARG_TYPE_MIDI, ARG_TYPE_TRUE, ARG_TYPE_FALSE, ARG_TYPE_NIL)
 
-    def __init__(self, address: str=None) -> None:
+    def __init__(self, address: Optional[str] = None) -> None:
         """Initialize a new builder for a message.
 
         Args:
@@ -69,7 +66,7 @@ class OscMessageBuilder(object):
             return True
         return False
 
-    def add_arg(self, arg_value: ArgValue, arg_type: str=None) -> None:
+    def add_arg(self, arg_value: ArgValue, arg_type: Optional[str] = None) -> None:
         """Add a typed argument to this message.
 
         Args:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -49,7 +49,7 @@ def _is_valid_request(request: _RequestType) -> bool:
 class OSCUDPServer(socketserver.UDPServer):
     """Superclass for different flavors of OSC UDP servers"""
 
-    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate: bool = True) -> None:  # type: ignore[call-arg]  # https://github.com/python/typeshed/pull/8542
+    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate: bool = True) -> None:
         """Initialize
 
         Args:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -49,7 +49,7 @@ def _is_valid_request(request: _RequestType) -> bool:
 class OSCUDPServer(socketserver.UDPServer):
     """Superclass for different flavors of OSC UDP servers"""
 
-    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate: bool = True) -> None:
+    def __init__(self, server_address: Tuple[str, int], dispatcher: Dispatcher, bind_and_activate: bool = True) -> None:  # type: ignore[call-arg]  # https://github.com/python/typeshed/pull/8542
         """Initialize
 
         Args:

--- a/pythonosc/osc_server.py
+++ b/pythonosc/osc_server.py
@@ -57,7 +57,7 @@ class OSCUDPServer(socketserver.UDPServer):
             dispatcher: Dispatcher this server will use
             (optional) bind_and_activate: default=True defines if the server has to start on call of constructor  
         """
-        super().__init__(server_address, _UDPHandler, bind_and_activate)  # type: ignore[call-arg]  # https://github.com/python/typeshed/pull/8542
+        super().__init__(server_address, _UDPHandler, bind_and_activate)
         self._dispatcher = dispatcher
 
     def verify_request(self, request: _RequestType, client_address: _AddressType) -> bool:

--- a/pythonosc/test/test_osc_message.py
+++ b/pythonosc/test/test_osc_message.py
@@ -34,7 +34,8 @@ _DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS = (
     b"/SYNC\x00\x00\x00"
     b"T"  # True
     b"F"  # False
-    b"[]th\x00\x00"  # Empty array
+    b"N"  # Nil
+    b"[]th\x00"  # Empty array
     b"\x00\x00\x00\x00\x00\x00\x00\x00"
     b"\x00\x00\x00\xe8\xd4\xa5\x10\x00"  # 1000000000000
 )
@@ -100,13 +101,14 @@ class TestOscMessage(unittest.TestCase):
         msg = osc_message.OscMessage(_DGRAM_ALL_NON_STANDARD_TYPES_OF_PARAMS)
 
         self.assertEqual("/SYNC", msg.address)
-        self.assertEqual(5, len(msg.params))
+        self.assertEqual(6, len(msg.params))
         self.assertEqual(True, msg.params[0])
         self.assertEqual(False, msg.params[1])
-        self.assertEqual([], msg.params[2])
-        self.assertEqual((datetime(1900, 1, 1, 0, 0, 0), 0), msg.params[3])
-        self.assertEqual(1000000000000, msg.params[4])
-        self.assertEqual(5, len(list(msg)))
+        self.assertEqual(None, msg.params[2])
+        self.assertEqual([], msg.params[3])
+        self.assertEqual((datetime(1900, 1, 1, 0, 0, 0), 0), msg.params[4])
+        self.assertEqual(1000000000000, msg.params[5])
+        self.assertEqual(6, len(list(msg)))
 
     def test_complex_array_params(self):
         msg = osc_message.OscMessage(_DGRAM_COMPLEX_ARRAY_PARAMS)

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -53,7 +53,7 @@ class TestOscMessageBuilder(unittest.TestCase):
         msg = builder.build()
         self.assertEqual("/SEEK", msg.address)
         self.assertSequenceEqual(
-            [4.0, 2, 1099511627776, "value", True, False, b"\x01\x02\x03", [1, ["abc"]]] * 2 +
+            [4.0, 2, 1099511627776, "value", True, False, b"\x01\x02\x03", [1, ["abc"]], None] * 2 +
             [4278255360, (1, 145, 36, 125), 1e-9],
             msg.params)
 


### PR DESCRIPTION
This PR adds support for creating and parsing messages with a `Nil` argument type. Arguments of `Nil` type are mapped to a python `None` (and vice versa).

I have added unit tests for the new functionality, and verified third-party compatibility by sending/receiving messages containing nil parameters with `liblo`.

I needed this for some features I'm developing for [AbletonOSC](https://github.com/ideoforms/AbletonOSC), in which OSC endpoints need to return lists of arguments which may contain one or more nil values.

Thanks for the great library!