### PR TITLE
Add options to UdpClient to force the use of IPv4 when IPv6 is available and vice versa

### DIFF
--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -18,7 +18,7 @@ from typing import Union
 class UDPClient(object):
     """OSC client to send :class:`OscMessage` or :class:`OscBundle` via UDP"""
 
-    def __init__(self, address: str, port: int, allow_broadcast: bool = False, force_ipv4 = False, force_ipv6 = False) -> None:
+    def __init__(self, address: str, port: int, allow_broadcast: bool = False, family: socket.AddressFamily = 0) -> None:
         """Initialize client
 
         As this is UDP it will not actually make any attempt to connect to the
@@ -28,18 +28,8 @@ class UDPClient(object):
             address: IP address of server
             port: Port of server
             allow_broadcast: Allow for broadcast transmissions
-            force_ipv4: require that remote address is IPv4
-            force_ipv6: require thta remote address is IPv6
+            family: address family parameter (passed to socket.getaddrinfo)
         """
-
-        if force_ipv4 and force_ipv6:
-            raise ValueError("Can only force one of IPv4 or IPv6")
-        elif force_ipv4:
-            family = socket.AF_INET
-        elif force_ipv6:
-            family = socket.AF_INET6
-        else:
-            family = 0
 
         for addr in socket.getaddrinfo(address, port, type=socket.SOCK_DGRAM, family=family):
             af, socktype, protocol, canonname, sa = addr

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -15,11 +15,13 @@ from pythonosc.osc_bundle import OscBundle
 
 from typing import Union
 
+class UdpClientException(Exception):
+    pass
 
 class UDPClient(object):
     """OSC client to send :class:`OscMessage` or :class:`OscBundle` via UDP"""
 
-    def __init__(self, address: str, port: int, allow_broadcast: bool = False) -> None:
+    def __init__(self, address: str, port: int, allow_broadcast: bool = False, force_ipv4 = False, force_ipv6 = False) -> None:
         """Initialize client
 
         As this is UDP it will not actually make any attempt to connect to the
@@ -29,8 +31,20 @@ class UDPClient(object):
             address: IP address of server
             port: Port of server
             allow_broadcast: Allow for broadcast transmissions
+            force_ipv4: require that remote address is IPv4
+            force_ipv6: require thta remote address is IPv6
         """
-        for addr in socket.getaddrinfo(address, port, type=socket.SOCK_DGRAM):
+
+        if force_ipv4 and force_ipv6:
+            raise ValueError("Can only force one of IPv4 or IPv6")
+        elif force_ipv4:
+            family = socket.AF_INET
+        elif force_ipv6:
+            family = socket.AF_INET6
+        else:
+            family = 0
+
+        for addr in socket.getaddrinfo(address, port, type=socket.SOCK_DGRAM, family=family):
             af, socktype, protocol, canonname, sa = addr
 
             try:

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -15,9 +15,6 @@ from pythonosc.osc_bundle import OscBundle
 
 from typing import Union
 
-class UdpClientException(Exception):
-    pass
-
 class UDPClient(object):
     """OSC client to send :class:`OscMessage` or :class:`OscBundle` via UDP"""
 

--- a/pythonosc/udp_client.py
+++ b/pythonosc/udp_client.py
@@ -18,7 +18,7 @@ from typing import Union
 class UDPClient(object):
     """OSC client to send :class:`OscMessage` or :class:`OscBundle` via UDP"""
 
-    def __init__(self, address: str, port: int, allow_broadcast: bool = False, family: socket.AddressFamily = 0) -> None:
+    def __init__(self, address: str, port: int, allow_broadcast: bool = False, family: socket.AddressFamily = socket.AF_UNSPEC) -> None:
         """Initialize client
 
         As this is UDP it will not actually make any attempt to connect to the


### PR DESCRIPTION
If getaddrinfo returns multiple addresses, udp_client always chooses the first one for which it can create a socket. So if I have a server on a machine set to listen to e.g. "0.0.0.0", and the client refers to the machine by name, there is a possibility that it will choose an IPv6 address, and the two will fail to connect. This simple addition allows the user of the UdpClient to require one or the other.