### PR TITLE
Add a SLIP client for OSC over serial ports.

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest mypy
+        python -m pip install flake8 pytest mypy pyserial
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/examples/slip_2way.py
+++ b/examples/slip_2way.py
@@ -1,0 +1,30 @@
+""" Simple example code for communicating with OSC devices over a serial port
+with SLIP wrapping. It will send a random value to the /filter address and then
+block until it receives a message back.
+"""
+import argparse
+import random
+
+from pythonosc.osc_message_builder import OscMessageBuilder
+
+from pythonosc import slip_client
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('device', help='TTY device to connect to', default='/dev/ttyACM0')
+    parser.add_argument('--baudrate', type=int, help='Set baudrate for serial port', default=115200)
+    args = parser.parse_args()
+
+    client = slip_client.SLIPClient(args.device, baudrate=args.baudrate)
+
+    # Send a message to /filter with a random value
+    builder = OscMessageBuilder("/filter")
+    builder.add_arg(random.random())
+    client.send(builder.build())
+
+    # Receive a message
+    message = client.receive()
+    if message is None:
+        print("Disconnected")
+    else:
+        print(message.address, message.params)

--- a/pythonosc/slip_client.py
+++ b/pythonosc/slip_client.py
@@ -1,0 +1,47 @@
+from typing import Union
+
+from pythonosc.osc_bundle import OscBundle
+from pythonosc.osc_message import OscMessage
+
+import serial  # type: ignore
+
+
+class SLIPClient:
+    END = b'\xc0'
+    ESC = b'\xdb'
+    ESC_END = b'\xdc'
+    ESC_ESC = b'\xdd'
+
+    def __init__(self, device, baudrate=9600, **kwargs):
+        self.ser = serial.Serial(device, baudrate=baudrate, **kwargs)
+
+    def send(self, content: Union[OscMessage, OscBundle]) -> None:
+        encoded = self.END
+        encoded += content.dgram.replace(self.ESC, self.ESC + self.ESC_ESC).replace(self.END, self.ESC + self.ESC_END)
+        encoded += self.END
+        self.ser.write(encoded)
+
+    def receive(self) -> Union[OscMessage, None]:
+        buffer = b''
+        while True:
+            c = self.ser.read(1)
+            if c is None:
+                return None
+
+            if c == self.END:
+                if len(buffer):
+                    break
+                continue
+
+            if c == self.ESC:
+                c = self.ser.read(1)
+                if c is None:
+                    return None
+                if c == self.ESC_END:
+                    buffer += self.END
+                elif c == self.ESC_ESC:
+                    buffer += self.ESC
+            else:
+                buffer += c
+
+        return OscMessage(buffer)


### PR DESCRIPTION
The OSC specification lets you send messages over any framed data channel and using the framing part of SLIP seems to be the most popular solution for devices allowing OSC control over USB.