### PR TITLE
Parse all OscMessages available within a packet's datagram

### DIFF
--- a/pythonosc/osc_message.py
+++ b/pythonosc/osc_message.py
@@ -20,12 +20,12 @@ class OscMessage(object):
     def __init__(self, dgram: bytes) -> None:
         self._dgram = dgram
         self._parameters = []  # type: List[Any]
-        self._parse_datagram()
+        self._dgram_tail = self._parse_datagram()
 
     def __str__(self):
         return f"{self.address} {' '.join(str(p) for p in self.params)}"
 
-    def _parse_datagram(self) -> None:
+    def _parse_datagram(self) -> bytes|None:
         try:
             self._address_regexp, index = osc_types.get_string(self._dgram, 0)
             if not self._dgram[index:]:
@@ -91,6 +91,13 @@ class OscMessage(object):
             self._parameters = params
         except osc_types.ParseError as pe:
             raise ParseError("Found incorrect datagram, ignoring it", pe)
+
+        if index < len(self._dgram):
+            tail = self._dgram[index:]
+            self._dgram = self.dgram[0:index]
+            return tail
+
+        return
 
     @property
     def address(self) -> str:

--- a/pythonosc/osc_packet.py
+++ b/pythonosc/osc_packet.py
@@ -68,7 +68,14 @@ class OscPacket(object):
                     key=lambda x: x.time,
                 )
             elif osc_message.OscMessage.dgram_is_message(dgram):
-                self._messages = [TimedMessage(now, osc_message.OscMessage(dgram))]
+                self._messages = []
+                while(True):
+                    msg = osc_message.OscMessage(dgram)
+                    self._messages.append(TimedMessage(now, msg))
+                    if msg._dgram_tail is None:
+                        break
+                    dgram = msg._dgram_tail
+
             else:
                 # Empty packet, should not happen as per the spec but heh, UDP...
                 raise ParseError(


### PR DESCRIPTION
A datagram can contain multiple OscMessages. This patch adds a field to an OscMessage containing the remaining (tail) bytes of its datagram. The OscPacket constructor continues to parse OscMessages from a datagram until all bytes are consumed.