### PR TITLE
Publish type annotations

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -38,3 +38,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+
+  check-types-published:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: |
+          pip install build
+          python -m build --sdist --wheel
+
+          temp=$(mktemp -d)
+
+          python -m venv $temp/venv
+          source $temp/venv/bin/activate
+
+          pip install mypy ./dist/*whl
+
+          cd $temp
+
+          echo 'import pythonosc' > demo.py
+          mypy demo.py


### PR DESCRIPTION
Includes a CI check that the published types are recognised. This PR contains a CI run for just that commit, validating the expected failure mode.

Fixes https://github.com/attwad/python-osc/issues/182