### PR TITLE
Expect Dispatcher replies for TCP to be tuples, not lists

### DIFF
--- a/pythonosc/osc_tcp_server.py
+++ b/pythonosc/osc_tcp_server.py
@@ -75,7 +75,7 @@ class _TCPHandler1_0(socketserver.BaseRequestHandler):
             )
             # resp = _call_handlers_for_packet(data, self.server.dispatcher)
             for r in resp:
-                if not isinstance(r, list):
+                if not isinstance(r, tuple):
                     r = [r]
                 msg = osc_message_builder.build_msg(r[0], r[1:])
                 b = struct.pack("!I", len(msg.dgram))
@@ -117,7 +117,7 @@ class _TCPHandler1_1(socketserver.BaseRequestHandler):
                     p, self.client_address
                 )
                 for r in resp:
-                    if not isinstance(r, list):
+                    if not isinstance(r, tuple):
                         r = [r]
                     msg = osc_message_builder.build_msg(r[0], r[1:])
                     self.request.sendall(slip.encode(msg.dgram))
@@ -284,7 +284,7 @@ class AsyncOSCTCPServer:
                 buf, client_address
             )
             for r in result:
-                if not isinstance(r, list):
+                if not isinstance(r, tuple):
                     r = [r]
                 msg = osc_message_builder.build_msg(r[0], r[1:])
                 b = struct.pack("!I", len(msg.dgram))
@@ -319,7 +319,7 @@ class AsyncOSCTCPServer:
                     p, client_address
                 )
                 for r in result:
-                    if not isinstance(r, list):
+                    if not isinstance(r, tuple):
                         r = [r]
                     msg = osc_message_builder.build_msg(r[0], r[1:])
                     writer.write(slip.encode(msg.dgram))

--- a/pythonosc/test/test_osc_tcp_server.py
+++ b/pythonosc/test/test_osc_tcp_server.py
@@ -95,12 +95,12 @@ class TestTCP_1_1_Handler(unittest.TestCase):
 
     def test_response_with_args(self):
         def respond(*args, **kwargs):
-            return [
+            return (
                 "/SYNC",
                 1,
                 "2",
                 3.0,
-            ]
+            )
 
         self.dispatcher.map("/SYNC", respond)
         mock_sock = mock.Mock()
@@ -208,12 +208,12 @@ class TestTCP_1_0_Handler(unittest.TestCase):
 
     def test_response_with_args(self):
         def respond(*args, **kwargs):
-            return [
+            return (
                 "/SYNC",
                 1,
                 "2",
                 3.0,
-            ]
+            )
 
         self.dispatcher.map("/SYNC", respond)
         mock_sock = mock.Mock()
@@ -314,12 +314,12 @@ class TestAsync1_1Handler(unittest.IsolatedAsyncioTestCase):
 
     async def test_response_with_args(self):
         def respond(*args, **kwargs):
-            return [
+            return (
                 "/SYNC",
                 1,
                 "2",
                 3.0,
-            ]
+            )
 
         self.dispatcher.map("/SYNC", respond)
         self.mock_reader.read.side_effect = [_SIMPLE_MSG_NO_PARAMS_1_1, b""]
@@ -332,12 +332,12 @@ class TestAsync1_1Handler(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_response_with_args(self):
         async def respond(*args, **kwargs):
-            return [
+            return (
                 "/SYNC",
                 1,
                 "2",
                 3.0,
-            ]
+            )
 
         self.dispatcher.map("/SYNC", respond)
         self.mock_reader.read.side_effect = [_SIMPLE_MSG_NO_PARAMS_1_1, b""]


### PR DESCRIPTION
As mentioned in issue 176, according to the documentation one of the ways a callback function may pass a reply back to a client is by returning a message encapsulated thusly: `tuple(<Address>, <ArgValue>)`.

Whilst the code for the UDP servers does conform to this, the code to TCP servers was expecting `list(<Address>, <ArgValue>)` in all cases.

This PR resolves that, updating the tests as well.

Fixes #176 