### PR TITLE
fix: correct spelling of 'inferred'

### DIFF
--- a/pythonosc/osc_message_builder.py
+++ b/pythonosc/osc_message_builder.py
@@ -134,7 +134,7 @@ class OscMessageBuilder(object):
         elif arg_value is None:
             arg_type = self.ARG_TYPE_NIL
         else:
-            raise ValueError("Infered arg_value type is not supported")
+            raise ValueError("Inferred arg_value type is not supported")
         return arg_type
 
     def build(self) -> osc_message.OscMessage:

--- a/pythonosc/test/test_osc_message_builder.py
+++ b/pythonosc/test/test_osc_message_builder.py
@@ -19,7 +19,7 @@ class TestOscMessageBuilder(unittest.TestCase):
         builder = osc_message_builder.OscMessageBuilder("")
         self.assertRaises(ValueError, builder.add_arg, "what?", 1)
 
-    def test_add_arg_invalid_infered_type(self):
+    def test_add_arg_invalid_inferred_type(self):
         builder = osc_message_builder.OscMessageBuilder("")
         self.assertRaises(ValueError, builder.add_arg, {"name": "John"})
 


### PR DESCRIPTION
Small fix to the spelling of 'inferred'. 

This was picked up by our CI - the [`typos`](https://github.com/crate-ci/typos) spell-checker fixed the spelling in our code, but then the pytest error check failed:

```
=========================== short test summary info ============================
FAILED tests/test_udp.py::test_invalid_osc_message_values[invalid_values0] - AssertionError: Regex pattern did not match.
 Regex: 'Inferred arg_value type is not supported'
 Input: 'Infered arg_value type is not supported'
 ```