### PR TITLE
Adds TCPDispatch client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- Added TCPDispatchClient to tcp_client
 - Fixed TPC dispatcher type annotations
 
 ## [1.9.3]

--- a/pythonosc/tcp_client.py
+++ b/pythonosc/tcp_client.py
@@ -127,18 +127,18 @@ class TCPDispatchClient(SimpleTCPClient):
 
     dispatcher = Dispatcher()
 
-    def handle_messages(self, timeout: int = 30) -> None:
+    def handle_messages(self, timeout_sec: int = 30) -> None:
         """Wait :int:`timeout` seconds for a message from the server and process each message with the registered
         handlers.  Continue until a timeout occurs.
 
         Args:
             timeout: Time in seconds to wait for a message
         """
-        r = self.receive(timeout)
+        r = self.receive(timeout_sec)
         while r:
             for m in r:
                 self.dispatcher.call_handlers_for_packet(m, (self.address, self.port))
-                r = self.receive(timeout)
+            r = self.receive(timeout_sec)
 
 
 class AsyncTCPClient:

--- a/pythonosc/tcp_client.py
+++ b/pythonosc/tcp_client.py
@@ -122,7 +122,7 @@ class SimpleTCPClient(TCPClient):
             r = self.receive(timeout)
 
 class TCPDispatchClient(SimpleTCPClient):
-    """OSC Client that includes a :class:`Dispatcher` for handling responses and other messages from the server"""
+    """OSC TCP Client that includes a :class:`Dispatcher` for handling responses and other messages from the server"""
 
     dispatcher = Dispatcher()
 

--- a/pythonosc/tcp_client.py
+++ b/pythonosc/tcp_client.py
@@ -121,6 +121,25 @@ class SimpleTCPClient(TCPClient):
                 yield OscMessage(m)
             r = self.receive(timeout)
 
+class TCPDispatchClient(SimpleTCPClient):
+    """OSC Client that includes a :class:`Dispatcher` for handling responses and other messages from the server"""
+
+    dispatcher = Dispatcher()
+
+    def handle_messages(self, timeout: int = 30) -> None:
+        """Wait :int:`timeout` seconds for a message from the server and process each message with the registered
+        handlers.  Continue until a timeout occurs.
+
+        Args:
+            timeout: Time in seconds to wait for a message
+        """
+        r = self.receive(timeout)
+        while r:
+            for m in r:
+                self.dispatcher.call_handlers_for_packet(m, (self.address, self.port))
+                r = self.receive(timeout)
+
+
 
 class AsyncTCPClient:
     """Async OSC client to send :class:`OscMessage` or :class:`OscBundle` via TCP"""

--- a/pythonosc/tcp_client.py
+++ b/pythonosc/tcp_client.py
@@ -121,6 +121,7 @@ class SimpleTCPClient(TCPClient):
                 yield OscMessage(m)
             r = self.receive(timeout)
 
+
 class TCPDispatchClient(SimpleTCPClient):
     """OSC TCP Client that includes a :class:`Dispatcher` for handling responses and other messages from the server"""
 
@@ -138,7 +139,6 @@ class TCPDispatchClient(SimpleTCPClient):
             for m in r:
                 self.dispatcher.call_handlers_for_packet(m, (self.address, self.port))
                 r = self.receive(timeout)
-
 
 
 class AsyncTCPClient:


### PR DESCRIPTION
Adds a TCPDispatch client to tcp_client.py follow the same concept of the DispatchClient that is already in udp_client.py. Currently, there is only an async version in tcp_client.py.